### PR TITLE
Update conf.d commands for celery v5 in 6.x

### DIFF
--- a/template/_6.x_6.1_6.2_/docker/conf.d/celerybeat.conf
+++ b/template/_6.x_6.1_6.2_/docker/conf.d/celerybeat.conf
@@ -3,7 +3,7 @@
 ; ================================
 
 [program:celerybeat]
-	command=/root/.local/bin/celery beat -A {{project}} --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid
+	command=/root/.local/bin/celery -A {{project}}.celery beat --schedule=/tmp/celerybeat-schedule --loglevel=INFO --pidfile=/tmp/celerybeat.pid
 	directory=/web_root/{{project}}
 
     user=root

--- a/template/_6.x_6.1_6.2_/docker/conf.d/celeryd.conf
+++ b/template/_6.x_6.1_6.2_/docker/conf.d/celeryd.conf
@@ -3,7 +3,7 @@
 ; ==================================
 
 [program:celery]
-    command=/root/.local/bin/celery worker -A {{project}} --loglevel=INFO
+    command=/root/.local/bin/celery -A {{project}}.celery worker --loglevel=INFO
     directory=/web_root/{{project}}
 
     user=root


### PR DESCRIPTION
Order of command arguments has changed for celery v5 so this has been altered for docker conf.d files for version 6 of Arches