### PR TITLE
Update node install to use NVM #31

### DIFF
--- a/template/_6.x_6.1_6.2_/Dockerfile
+++ b/template/_6.x_6.1_6.2_/Dockerfile
@@ -16,6 +16,8 @@ ENV DATA_ROOT=${APP_ROOT}_data
 ENV ARCHES_ROOT=${WEB_ROOT}/arches
 ENV WHEELS=/wheels
 ENV PYTHONUNBUFFERED=1
+ENV NODE_VERSION 12.22.12
+
 
 RUN apt-get update && apt-get install -y make software-properties-common
 
@@ -30,6 +32,13 @@ RUN mkdir ${DATA_ROOT}
 # with everything enabled, and so, it has a huge amount of dependancies (everything that GDAL
 # support, directly and indirectly pulling in mysql-common, odbc, jp2, perl! ... )
 # a minimised build of GDAL could remove several hundred MB from the container layer.
+RUN apt-get install -y --no-install-recommends curl \
+  && apt-get update -y 
+
+RUN curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+  && apt-get update -y 
+
 RUN set -ex \
   && RUN_DEPS=" \
   build-essential \
@@ -38,14 +47,28 @@ RUN set -ex \
   postgresql-client-12 \
   dos2unix \
   " \
-  && apt-get install -y --no-install-recommends curl \
-  && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-  && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" \
-  && apt-get update -y \
-  && apt-get install -y --no-install-recommends $RUN_DEPS \
-  && apt-get install -y nodejs \
-  && npm install -g yarn
+ && apt-get install -y --no-install-recommends $RUN_DEPS
+
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir $NVM_DIR
+
+# install nvm
+# https://github.com/nvm-sh/nvm#install-script
+RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | bash -
+
+# install node and npm
+RUN echo "source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default" | bash -
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN npm install -g yarn && apt install wait-for-it
 
 RUN rm -rf /root/.cache/pip/*
 

--- a/template/_7.x_7.3_7.4_/Dockerfile
+++ b/template/_7.x_7.3_7.4_/Dockerfile
@@ -16,6 +16,7 @@ ENV DATA_ROOT=${APP_ROOT}_data
 ENV ARCHES_ROOT=${WEB_ROOT}/arches
 ENV WHEELS=/wheels
 ENV PYTHONUNBUFFERED=1
+ENV NODE_VERSION 14.21.3
 
 RUN apt-get update && apt-get install -y make software-properties-common
 
@@ -30,6 +31,13 @@ RUN mkdir ${DATA_ROOT}
 # with everything enabled, and so, it has a huge amount of dependancies (everything that GDAL
 # support, directly and indirectly pulling in mysql-common, odbc, jp2, perl! ... )
 # a minimised build of GDAL could remove several hundred MB from the container layer.
+RUN apt-get install -y --no-install-recommends curl \
+  && apt-get update -y 
+
+RUN curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+  && apt-get update -y 
+
 RUN set -ex \
   && RUN_DEPS=" \
   build-essential \
@@ -38,14 +46,29 @@ RUN set -ex \
   postgresql-client-14 \
   dos2unix \
   " \
-  && apt-get install -y --no-install-recommends curl \
-  && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
-  && curl -sL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" \
-  && apt-get update -y \
-  && apt-get install -y --no-install-recommends $RUN_DEPS \
-  && apt-get install -y nodejs \
-  && npm install -g yarn
+ && apt-get install -y --no-install-recommends $RUN_DEPS
+
+
+# nvm environment variables
+ENV NVM_DIR /usr/local/nvm
+RUN mkdir $NVM_DIR
+
+# install nvm
+# https://github.com/nvm-sh/nvm#install-script
+RUN curl --silent -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.4/install.sh | bash -
+
+# install node and npm
+RUN echo "source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default" | bash -
+
+# add node and npm to path so the commands are available
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+RUN npm install -g yarn && apt install wait-for-it
+
 
 RUN rm -rf /root/.cache/pip/*
 

--- a/template/_7.x_7.3_7.4_/docker-compose.yml
+++ b/template/_7.x_7.3_7.4_/docker-compose.yml
@@ -66,18 +66,13 @@ services:
     
     {{project_urlsafe}}-webpack:
       container_name: {{project_urlsafe}}-webpack
-      image: he/{{project}}_webpack-7-0
-      build:
-        args:
-          - "DOCKER_PATH=./arches-containers/projects/{{project}}/docker"
-        context: ../../..
-        dockerfile: ./arches-containers/projects/{{project}}/docker/webpack/Dockerfile
+      image: he/{{project}}:dev_build
       command: run_webpack
       volumes:
         - ../../../arches:/web_root/arches
         - ../../../{{project}}:/web_root/{{project}}
       env_file:
-        - ./docker/webpack/env_file.env
+        - ./docker/env_file.env
       ports:
         - 8028:8021
       depends_on:

--- a/template/_7.x_7.3_7.4_/docker/entrypoint.sh
+++ b/template/_7.x_7.3_7.4_/docker/entrypoint.sh
@@ -187,6 +187,15 @@ run_livereload() {
 	run_livereload_server
 }
 
+run_webpack() {
+	echo ""
+	echo "----- *** RUNNING WEBPACK DEVELOPMENT SERVER *** -----"
+	echo ""
+	cd ${APP_FOLDER}
+    echo "Running Webpack"
+	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/{{project}} && yarn install && yarn start"
+}
+
 ### Starting point ###
 
 # trying not to use virtualenv???

--- a/template/_7.x_7.3_7.4_/docker/env_file.env
+++ b/template/_7.x_7.3_7.4_/docker/env_file.env
@@ -34,3 +34,6 @@ RABBITMQ_USER=guest
 RABBITMQ_PASS=guest
 RABBITMQ_HOST=rabbitmq-{{project_urlsafe}}
 
+#webpack
+NODE_OPTIONS=--max-old-space-size=10000
+


### PR DESCRIPTION
To match the 7.5 template, need to update the 7.x-7.4 and 6.2 templates to use the same process.

this was done as the nodesource install approach is deprecated and the warning shown during the docker build step was causing a 1 minute pause.

While there I also made 7.4 template match the pattern in used where the webpack container uses the same build image as the application and but runs a different command on entrypoint.sh

Fixes #31 