### PR TITLE
Fixes issue creating new applications due to project directory clash

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,9 +53,9 @@ git checkout dev/7.4.x
 ```
 Navigate you your container project directory.
 
-Compose up the `docker-compose-dependencies.yml` first. Once the dependencies are up, compose up the `docker-compose.yml`.
+If the arches project does not already exist at the root of the workspace then compose up the Compose up the `docker-compose-init.yml` first to generate the project. If you do want to use an existing arches project then ensure the repo has been cloned to the root of workspace first.
 
-If the arches project does not already exist at the root of the workspace then it'll be created. If you do want to use an existing arches project then ensure the repo has been cloned to the root of workspace first.
+Next compose up the `docker-compose-dependencies.yml` to create and start all the service dependencies. Once the dependencies are up, compose up the `docker-compose.yml`.
 
 If you are using this to create a new arches project, this may take a few minutes to complete building everything.
 

--- a/template/_6.x_6.1_6.2_/Dockerfile
+++ b/template/_6.x_6.1_6.2_/Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get update && apt-get install -y make software-properties-common
 
 # Get the pre-built python wheels from the build environment
 RUN mkdir ${WEB_ROOT}
-RUN mkdir ${APP_ROOT}
 RUN mkdir ${PKG_ROOT}
 RUN mkdir ${DATA_ROOT}
 
@@ -98,7 +97,7 @@ RUN mkdir /var/log/supervisor
 RUN mkdir /var/log/celery
 
 # Set default workdir
-WORKDIR ${APP_ROOT}
+WORKDIR ${WEB_ROOT}
 
 # # Set entrypoint
 ENTRYPOINT ["/entrypoint.sh"]

--- a/template/_6.x_6.1_6.2_/docker-compose-init.yml
+++ b/template/_6.x_6.1_6.2_/docker-compose-init.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 services:
-    {{project_urlsafe}}::
+    {{project_urlsafe}}:
       container_name: {{project_urlsafe}}:
       image: he/{{project}}:dev_build
       build:

--- a/template/_6.x_6.1_6.2_/docker-compose-init.yml
+++ b/template/_6.x_6.1_6.2_/docker-compose-init.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+    {{project_urlsafe}}::
+      container_name: {{project_urlsafe}}:
+      image: he/{{project}}:dev_build
+      build:
+        args:
+          - "PROJ_NAME={{project}}"
+          - "DOCKER_PATH=./arches-containers/projects/{{project}}/docker"
+        context: ../../..
+        dockerfile: ./arches-containers/projects/{{project}}/Dockerfile
+      command: create_project
+      volumes:
+        - ../../..:/web_root
+      env_file:
+        - ./docker/env_file.env
+      ports:
+        - 8002:8000
+        - 5678:5678
+      stdin_open: true
+      tty: true

--- a/template/_6.x_6.1_6.2_/docker-compose-init.yml
+++ b/template/_6.x_6.1_6.2_/docker-compose-init.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
     {{project_urlsafe}}:
-      container_name: {{project_urlsafe}}:
+      container_name: {{project_urlsafe}}
       image: he/{{project}}:dev_build
       build:
         args:

--- a/template/_6.x_6.1_6.2_/docker/entrypoint.sh
+++ b/template/_6.x_6.1_6.2_/docker/entrypoint.sh
@@ -96,7 +96,7 @@ init_arches() {
 		echo "Skipping Package Loading"
 	else
 		echo "Database ${PGDBNAME} does not exists yet."
-		run_load_package #change to run_load_package if preferred 
+		run_setup_db #change to run_load_package if preferred 
 	fi
 }
 

--- a/template/_6.x_6.1_6.2_/docker/entrypoint.sh
+++ b/template/_6.x_6.1_6.2_/docker/entrypoint.sh
@@ -10,6 +10,9 @@ else
 	PACKAGE_JSON_FOLDER=${ARCHES_ROOT}
 fi
 
+# SET DEFAULT WORKING DIRECTORY
+cd ${APP_FOLDER}
+
 YARN_MODULES_FOLDER=${PACKAGE_JSON_FOLDER}/$(awk \
 	-F '--install.modules-folder' '{print $2}' ${PACKAGE_JSON_FOLDER}/.yarnrc \
 	| awk '{print $1}' \
@@ -52,7 +55,22 @@ db_exists() {
 
 	# Return 0 (= true) if database exists
 	if [[ ${count} > 0 ]]; then
-		return 0
+		echo "Checking if database is setup "${PGDBNAME}"..."
+		tcount=`psql --host=${PGHOST} --port=${PGPORT} --user=${PGUSERNAME} --dbname=${PGDBNAME} -Atc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'nodes'"`
+		# Check if returned value is a number and not some error message
+		re='^[0-9]+$'
+		if ! [[ ${tcount} =~ $re ]] ; then
+		echo "Error: Something went wrong when checking if tables exists in database "${PGDBNAME}"..." >&2;
+		echo "Exiting..."
+		exit 1
+		fi
+
+		# Return 0 (= true) if table exists
+		if [[ ${tcount} > 0 ]]; then
+			return 0
+		else
+			return 1
+		fi
 	else
 		return 1
 	fi
@@ -78,8 +96,18 @@ init_arches() {
 		echo "Skipping Package Loading"
 	else
 		echo "Database ${PGDBNAME} does not exists yet."
-		run_load_package #change to run_load_package if preferred
+		run_load_package #change to run_load_package if preferred 
 	fi
+}
+
+create_arches_project_only(){
+	echo ""
+	echo "----- Creating '${ARCHES_PROJECT}'... -----"
+	echo ""
+
+	cd ${WEB_ROOT}
+	python3 ${WEB_ROOT}/arches/arches/install/arches-project create ${ARCHES_PROJECT}
+	APP_FOLDER=${WEB_ROOT}/${ARCHES_PROJECT}
 }
 
 create_arches_project() {
@@ -88,12 +116,9 @@ create_arches_project() {
 		echo ""
 		echo "----- Creating '${ARCHES_PROJECT}'... -----"
 		echo ""
-
-		cd ${APP_FOLDER}
-		python3 ${WEB_ROOT}/arches/arches/install/arches-project create ${ARCHES_PROJECT} -d .
+		create_arches_project_only
 		copy_settings_local
 		run_setup_db
-		setup_couchdb
 
 		exit_code=$?
 		if [[ ${exit_code} != 0 ]]; then
@@ -149,8 +174,13 @@ run_setup_db() {
 	echo ""
 	echo "----- RUNNING SETUP_DB -----"
 	echo ""
-	cd ${APP_FOLDER}
-	python3 manage.py setup_db --force
+	if [[ -d ${WEB_ROOT}/${ARCHES_PROJECT}/pkg ]];then
+		python3 manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg -db -dev -y
+	else
+		cd ${WEB_ROOT}/${ARCHES_PROJECT}
+		python3 manage.py setup_db --force
+	fi
+	setup_couchdb
 }
 
 run_load_package() {
@@ -211,6 +241,8 @@ run_livereload() {
 
 # If no arguments are supplied, assume the server needs to be run
 if [[ $#  -eq 0 ]]; then
+	echo "No arguments supplied, running Arches server..."
+	copy_settings_local
 	start_celery_supervisor
 	wait_for_db
 	run_arches
@@ -225,19 +257,13 @@ do
 
 	case ${key} in
 		run_arches)
-			start_celery_supervisor
 			copy_settings_local
 			wait_for_db
+			start_celery_supervisor
 			run_arches
 		;;
 		run_livereload)
 			run_livereload_server
-		;;
-		setup_arches)
-			start_celery_supervisor
-			copy_settings_local
-			wait_for_db
-			setup_arches
 		;;
 		run_tests)
 			copy_settings_local
@@ -249,11 +275,8 @@ do
 			wait_for_db
 			run_migrations
 		;;
-		install_yarn_components)
-			install_yarn_components
-		;;
 		create_project)
-			create_arches_project
+			create_arches_project_only
 		;;
 		help|-h)
 			display_help

--- a/template/_7.5_/Dockerfile
+++ b/template/_7.5_/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y make software-properties-common
 
 # Get the pre-built python wheels from the build environment
 RUN mkdir ${WEB_ROOT}
-RUN mkdir ${APP_ROOT}
 RUN mkdir ${PKG_ROOT}
 RUN mkdir ${DATA_ROOT}
 
@@ -99,7 +98,7 @@ RUN mkdir /var/log/supervisor
 RUN mkdir /var/log/celery
 
 # Set default workdir
-WORKDIR ${APP_ROOT}
+WORKDIR ${WEB_ROOT}
 
 # # Set entrypoint
 ENTRYPOINT ["/entrypoint.sh"]

--- a/template/_7.5_/docker-compose-init.yml
+++ b/template/_7.5_/docker-compose-init.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 services:
-    {{project_urlsafe}}::
+    {{project_urlsafe}}:
       container_name: {{project_urlsafe}}:
       image: he/{{project}}:dev_build
       build:

--- a/template/_7.5_/docker-compose-init.yml
+++ b/template/_7.5_/docker-compose-init.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+    {{project_urlsafe}}::
+      container_name: {{project_urlsafe}}:
+      image: he/{{project}}:dev_build
+      build:
+        args:
+          - "PROJ_NAME={{project}}"
+          - "DOCKER_PATH=./arches-containers/projects/{{project}}/docker"
+        context: ../../..
+        dockerfile: ./arches-containers/projects/{{project}}/Dockerfile
+      command: create_project
+      volumes:
+        - ../../..:/web_root
+      env_file:
+        - ./docker/env_file.env
+      ports:
+        - 8002:8000
+        - 5678:5678
+      stdin_open: true
+      tty: true

--- a/template/_7.5_/docker-compose-init.yml
+++ b/template/_7.5_/docker-compose-init.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
     {{project_urlsafe}}:
-      container_name: {{project_urlsafe}}:
+      container_name: {{project_urlsafe}}
       image: he/{{project}}:dev_build
       build:
         args:

--- a/template/_7.5_/docker/entrypoint.sh
+++ b/template/_7.5_/docker/entrypoint.sh
@@ -96,7 +96,7 @@ init_arches() {
 		echo "Skipping Package Loading"
 	else
 		echo "Database ${PGDBNAME} does not exists yet."
-		run_load_package #change to run_load_package if preferred 
+		run_setup_db #change to run_load_package if preferred 
 	fi
 }
 

--- a/template/_7.x_7.3_7.4_/Dockerfile
+++ b/template/_7.x_7.3_7.4_/Dockerfile
@@ -22,7 +22,6 @@ RUN apt-get update && apt-get install -y make software-properties-common
 
 # Get the pre-built python wheels from the build environment
 RUN mkdir ${WEB_ROOT}
-RUN mkdir ${APP_ROOT}
 RUN mkdir ${PKG_ROOT}
 RUN mkdir ${DATA_ROOT}
 
@@ -98,7 +97,7 @@ RUN mkdir /var/log/supervisor
 RUN mkdir /var/log/celery
 
 # Set default workdir
-WORKDIR ${APP_ROOT}
+WORKDIR ${WEB_ROOT}
 
 # # Set entrypoint
 ENTRYPOINT ["/entrypoint.sh"]

--- a/template/_7.x_7.3_7.4_/docker-compose-init.yml
+++ b/template/_7.x_7.3_7.4_/docker-compose-init.yml
@@ -1,6 +1,6 @@
 version: '3.8'
 services:
-    {{project_urlsafe}}::
+    {{project_urlsafe}}:
       container_name: {{project_urlsafe}}:
       image: he/{{project}}:dev_build
       build:

--- a/template/_7.x_7.3_7.4_/docker-compose-init.yml
+++ b/template/_7.x_7.3_7.4_/docker-compose-init.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+services:
+    {{project_urlsafe}}::
+      container_name: {{project_urlsafe}}:
+      image: he/{{project}}:dev_build
+      build:
+        args:
+          - "PROJ_NAME={{project}}"
+          - "DOCKER_PATH=./arches-containers/projects/{{project}}/docker"
+        context: ../../..
+        dockerfile: ./arches-containers/projects/{{project}}/Dockerfile
+      command: create_project
+      volumes:
+        - ../../..:/web_root
+      env_file:
+        - ./docker/env_file.env
+      ports:
+        - 8002:8000
+        - 5678:5678
+      stdin_open: true
+      tty: true

--- a/template/_7.x_7.3_7.4_/docker-compose-init.yml
+++ b/template/_7.x_7.3_7.4_/docker-compose-init.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
     {{project_urlsafe}}:
-      container_name: {{project_urlsafe}}:
+      container_name: {{project_urlsafe}}
       image: he/{{project}}:dev_build
       build:
         args:

--- a/template/_7.x_7.3_7.4_/docker/entrypoint.sh
+++ b/template/_7.x_7.3_7.4_/docker/entrypoint.sh
@@ -96,7 +96,7 @@ init_arches() {
 		echo "Skipping Package Loading"
 	else
 		echo "Database ${PGDBNAME} does not exists yet."
-		run_load_package #change to run_load_package if preferred 
+		run_setup_db #change to run_load_package if preferred 
 	fi
 }
 

--- a/template/_7.x_7.3_7.4_/docker/entrypoint.sh
+++ b/template/_7.x_7.3_7.4_/docker/entrypoint.sh
@@ -10,6 +10,9 @@ else
 	PACKAGE_JSON_FOLDER=${ARCHES_ROOT}
 fi
 
+# SET DEFAULT WORKING DIRECTORY
+cd ${APP_FOLDER}
+
 YARN_MODULES_FOLDER=${PACKAGE_JSON_FOLDER}/$(awk \
 	-F '--install.modules-folder' '{print $2}' ${PACKAGE_JSON_FOLDER}/.yarnrc \
 	| awk '{print $1}' \
@@ -52,7 +55,22 @@ db_exists() {
 
 	# Return 0 (= true) if database exists
 	if [[ ${count} > 0 ]]; then
-		return 0
+		echo "Checking if database is setup "${PGDBNAME}"..."
+		tcount=`psql --host=${PGHOST} --port=${PGPORT} --user=${PGUSERNAME} --dbname=${PGDBNAME} -Atc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'nodes'"`
+		# Check if returned value is a number and not some error message
+		re='^[0-9]+$'
+		if ! [[ ${tcount} =~ $re ]] ; then
+		echo "Error: Something went wrong when checking if tables exists in database "${PGDBNAME}"..." >&2;
+		echo "Exiting..."
+		exit 1
+		fi
+
+		# Return 0 (= true) if table exists
+		if [[ ${tcount} > 0 ]]; then
+			return 0
+		else
+			return 1
+		fi
 	else
 		return 1
 	fi
@@ -82,15 +100,23 @@ init_arches() {
 	fi
 }
 
+create_arches_project_only(){
+	echo ""
+	echo "----- Creating '${ARCHES_PROJECT}'... -----"
+	echo ""
+
+	cd ${WEB_ROOT}
+	python3 ${WEB_ROOT}/arches/arches/install/arches-project create ${ARCHES_PROJECT}
+	APP_FOLDER=${WEB_ROOT}/${ARCHES_PROJECT}
+}
+
 create_arches_project() {
 	echo "Checking if Arches project "${ARCHES_PROJECT}" exists..."
 	if [[ ! -d ${APP_FOLDER}/${ARCHES_PROJECT} ]] || [[ ! "$(ls ${APP_FOLDER}/${ARCHES_PROJECT})" ]]; then
 		echo ""
 		echo "----- Creating '${ARCHES_PROJECT}'... -----"
 		echo ""
-
-		cd ${APP_FOLDER}
-		python3 ${WEB_ROOT}/arches/arches/install/arches-project create ${ARCHES_PROJECT} -d .
+		create_arches_project_only
 		copy_settings_local
 		run_setup_db
 
@@ -140,8 +166,12 @@ run_setup_db() {
 	echo ""
 	echo "----- RUNNING SETUP_DB -----"
 	echo ""
-	cd ${APP_FOLDER}
-	python3 manage.py setup_db --force
+	if [[ -d ${WEB_ROOT}/${ARCHES_PROJECT}/pkg ]];then
+		python3 manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg -db -dev -y
+	else
+		cd ${WEB_ROOT}/${ARCHES_PROJECT}
+		python3 manage.py setup_db --force
+	fi
 }
 
 run_load_package() {
@@ -149,7 +179,9 @@ run_load_package() {
 	echo "----- *** LOADING PACKAGE: ${ARCHES_PROJECT} *** -----"
 	echo ""
 	cd ${APP_FOLDER}
-	python3 manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg -db -dev -y
+	if [[ -d ${ARCHES_PROJECT}/pkg ]];then
+		python3 manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg -db -dev -y
+	fi
 }
 
 # "exec" means that it will finish building???
@@ -208,6 +240,8 @@ run_webpack() {
 
 # If no arguments are supplied, assume the server needs to be run
 if [[ $#  -eq 0 ]]; then
+	echo "No arguments supplied, running Arches server..."
+	copy_settings_local
 	start_celery_supervisor
 	wait_for_db
 	run_arches
@@ -222,19 +256,16 @@ do
 
 	case ${key} in
 		run_arches)
-			start_celery_supervisor
 			copy_settings_local
 			wait_for_db
+			start_celery_supervisor
 			run_arches
 		;;
 		run_livereload)
 			run_livereload_server
 		;;
-		setup_arches)
-			start_celery_supervisor
-			copy_settings_local
-			wait_for_db
-			setup_arches
+		run_webpack)
+			run_webpack
 		;;
 		run_tests)
 			copy_settings_local
@@ -246,11 +277,8 @@ do
 			wait_for_db
 			run_migrations
 		;;
-		install_yarn_components)
-			install_yarn_components
-		;;
 		create_project)
-			create_arches_project
+			create_arches_project_only
 		;;
 		help|-h)
 			display_help


### PR DESCRIPTION
Made changes to the steps to create a new project using arches-containers

The issue was that the arches project folder is created due to it being a mounted volume, which then raises an error seen in this issue: https://github.com/archesproject/arches/issues/10166. This is because the django command it is based on does not like the fact that the folder already exists, even if using the `-d` flag to specify a folder.

To fix it, we needed an initialisation step that mounts the whole workspace and then simply runs `arches-project create` to create it all before running the normal `docker-compose.yml`.

Once this step is complete, normal steps can be used.

fixes #34 