### PR TITLE
webpack - fix path for arches_her - second level folder is always arches_her

### DIFF
--- a/template/_7.5_/docker/entrypoint.sh
+++ b/template/_7.5_/docker/entrypoint.sh
@@ -225,7 +225,7 @@ run_webpack() {
 	echo ""
 	cd ${APP_FOLDER}
     echo "Running Webpack"
-	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/{{project}} && yarn install && yarn start"
+	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/arches_her && yarn install && yarn start"
 }
 
 ### Starting point ###

--- a/template/_7.x_7.3_7.4_/docker/entrypoint.sh
+++ b/template/_7.x_7.3_7.4_/docker/entrypoint.sh
@@ -225,7 +225,7 @@ run_webpack() {
 	echo ""
 	cd ${APP_FOLDER}
     echo "Running Webpack"
-	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/{{project}} && yarn install && yarn start"
+	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/arches_her && yarn install && yarn start"
 }
 
 ### Starting point ###

--- a/template/_7.x_7.3_7.4_/docker/webpack/entrypoint.sh
+++ b/template/_7.x_7.3_7.4_/docker/webpack/entrypoint.sh
@@ -7,7 +7,7 @@ run_webpack() {
 	echo ""
 	cd ${APP_FOLDER}
     echo "Running Webpack"
-	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/{{project}} && yarn install && yarn start"
+	exec sh -c "wait-for-it {{project_urlsafe}}:${DJANGO_PORT} -t 1200 && cd /web_root/{{project}}/arches_her && yarn install && yarn start"
 }
 
 run_webpack


### PR DESCRIPTION
If you clone arches_her repo to arches_afher for example (`git clone https://github.com/historicengland/arches_her.git arches_afher`), cloning creates the `arches_afher` folder but the inner folder remains `arches_her`. The webpack runner incorrectly tries to change directory to /web_root/arches_afher/_arches_afher_  instead of /web_root/arches_afher/**arches_her**