### PR TITLE
Refactor Dockerfile to use specific version of pip #41

### DIFF
--- a/template/_6.x_6.1_6.2_/Dockerfile
+++ b/template/_6.x_6.1_6.2_/Dockerfile
@@ -79,7 +79,7 @@ RUN chmod +x ${ARCHES_ROOT}/arches/install/arches-project
 # From here, run commands from ARCHES_ROOT
 WORKDIR ${ARCHES_ROOT}
 
-RUN pip install --upgrade pip setuptools wheel
+RUN pip install --upgrade "pip<24.1" setuptools wheel
 RUN pip install -e . --user --no-use-pep517 && pip install -r arches/install/requirements_dev.txt
 
 COPY $DOCKER_PATH/entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Issues with pip>=24.1 not being able to install celery==4.4.4 meant that v6 project docker images fail to setup.  We can't upgrade v6 code at this point so need to fix the verion