### PR TITLE
Adds restart command

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
     steps:

--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.0.0rc1"
+AC_VERSION = "1.0.0rc2"

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -30,17 +30,26 @@ def main():
     parser_up.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
     parser_up.add_argument("-b", "--build", action="store_true", help="Rebuild containers when composing up")
     parser_up.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
+    container_group_up = parser_up.add_mutually_exclusive_group()
+    container_group_up.add_argument("--app", action="store_true", help="Only operate on application containers (docker-compose.yml)")
+    container_group_up.add_argument("--dep", action="store_true", help="Only operate on dependency containers (docker-compose-dependencies.yml)")
 
     # Sub-parser for stopping containers
     parser_down = subparsers.add_parser("down", help="Stop the project containers", formatter_class=parser.formatter_class)
     parser_down.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
     parser_down.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
+    container_group_down = parser_down.add_mutually_exclusive_group()
+    container_group_down.add_argument("--app", action="store_true", help="Only operate on application containers (docker-compose.yml)")
+    container_group_down.add_argument("--dep", action="store_true", help="Only operate on dependency containers (docker-compose-dependencies.yml)")
 
     # Sub-parser for restarting containers
     parser_restart = subparsers.add_parser("restart", help="Restart the project containers (down + up)", formatter_class=parser.formatter_class)
     parser_restart.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
     parser_restart.add_argument("-b", "--build", action="store_true", help="Rebuild containers when composing up")
     parser_restart.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
+    container_group_restart = parser_restart.add_mutually_exclusive_group()
+    container_group_restart.add_argument("--app", action="store_true", help="Only operate on application containers (docker-compose.yml)")
+    container_group_restart.add_argument("--dep", action="store_true", help="Only operate on dependency containers (docker-compose-dependencies.yml)")
 
     # Sub-parser for initializing project
     parser_init = subparsers.add_parser("init", help="Initialize the project", formatter_class=parser.formatter_class)
@@ -123,13 +132,17 @@ def main():
                 initialize_project(args.project_name, args.verbose)
             elif args.command == "restart":
                 arches_repo_helper.change_arches_branch(args.project_name, verbose=args.verbose)
+                # Determine container type
+                container_type = "app" if getattr(args, 'app', False) else "dep" if getattr(args, 'dep', False) else "both"
                 # First bring containers down
-                compose_project(args.project_name, "down", False, args.verbose)
+                compose_project(args.project_name, "down", False, args.verbose, container_type)
                 # Then bring them up, with build if requested
-                compose_project(args.project_name, "up", getattr(args, 'build', False), args.verbose)
+                compose_project(args.project_name, "up", getattr(args, 'build', False), args.verbose, container_type)
             else:
                 arches_repo_helper.change_arches_branch(args.project_name, verbose=args.verbose)
-                compose_project(args.project_name, args.command, getattr(args, 'build', False), args.verbose)
+                # Determine container type
+                container_type = "app" if getattr(args, 'app', False) else "dep" if getattr(args, 'dep', False) else "both"
+                compose_project(args.project_name, args.command, getattr(args, 'build', False), args.verbose, container_type)
 
     # ========================================================================================================
     elif args.command == "list":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "arches-containers"
 version = "1.0.0rc2"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Supports Arches 6.1 to 8.0 (current development version)."
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }
 keywords = ["arches", "development", "containers"]
 classifiers = [
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.0.0rc1"
+version = "1.0.0rc2"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Supports Arches 6.1 to 8.0 (current development version)."
 requires-python = ">=3.8"
 license = { text = "AGPL-3.0" }

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,7 @@ It is recommended that you use a virtual environment within the workspace. The f
 cd /path/to/workspace
 python -m venv env
 source env/bin/activate  # On Windows use `env\Scripts\activate`
+
 ```
 
 > See the [Arches documentation](https://arches.readthedocs.io/en/stable/installing/installation/) for more information.
@@ -118,6 +119,33 @@ act down [-p <project_name>] [-vb]
 - `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
 
+#### Restart a Project
+
+Restarts the project containers by stopping and then starting them. Useful for applying changes such as new dependencies or forcing a rebuild.
+
+```sh
+cd /path/to/workspace
+act restart [-p <project_name>] [-b] [-vb]
+```
+
+- `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
+- `-b`, `--build`: Rebuild containers when composing up (after stopping them).
+- `-vb`, `--verbose`: Print verbose output during the compose processes.
+
+**Examples:**
+
+Restart and force rebuild:
+
+```sh
+act restart -b
+```
+
+Restart with verbose output:
+
+```sh
+act restart -b -vb
+```
+
 #### Initialize a Project
 
 ```sh
@@ -195,6 +223,7 @@ act import -p <project_name> [-r <repo_path>]
 - `-r`, `--repo_path`: OPTIONAL - Use this is the name of the repo directory does not match the pattern `<workspace_path>/<project_name>`. This path **must** contain a folder called `.ac_<project_name>`.
 
 **example:**
+
 Given the following directory structure:
 
 ```text
@@ -249,8 +278,8 @@ The project configuration file `config.json` is used to store default values for
 
 ```json
 {
-    "project_name": "arches_her_project",
-    "project_name_url_safe": "archesherproject",
+  "project_name": "arches_her_project",
+  "project_name_url_safe": "archesherproject",
     "arches_version": "7.5",
     "arches_repo_organization": "archesproject",
     "arches_repo_branch": "dev/7.5.x"
@@ -295,13 +324,15 @@ Ensure the version number is updated in both pyproject.toml and the `arches_cont
 Also update the Development Status classifier in pyproject.toml to match your release type:
 
 - **For PyPI releases**:
-  ```
+  
+  ```text
   "Development Status :: 5 - Production/Stable"  # For final releases
   "Development Status :: 4 - Beta"               # For release candidates
   ```
 
 - **For TestPyPI releases**:
-  ```
+  
+  ```text
   "Development Status :: 3 - Alpha"              # For alpha/development releases
   "Development Status :: 4 - Beta"               # For beta releases
   ```

--- a/readme.md
+++ b/readme.md
@@ -102,22 +102,26 @@ The following commands are available for managing projects:
 
 ```sh
 cd /path/to/workspace
-act up [-p <project_name>] [-b] [-vb]
+act up [-p <project_name>] [-b] [-vb] [--app | --dep]
 ```
 
 - `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
 - `-b`, `--build`: Rebuild containers when composing up.
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
+- `--app`: Only operate on application containers (docker-compose.yml). Mutually exclusive with --dep.
+- `--dep`: Only operate on dependency containers (docker-compose-dependencies.yml). Mutually exclusive with --app.
 
 #### Stop a Project
 
 ```sh
 cd /path/to/workspace
-act down [-p <project_name>] [-vb]
+act down [-p <project_name>] [-vb] [--app | --dep]
 ```
 
 - `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
+- `--app`: Only operate on application containers (docker-compose.yml). Mutually exclusive with --dep.
+- `--dep`: Only operate on dependency containers (docker-compose-dependencies.yml). Mutually exclusive with --app.
 
 #### Restart a Project
 
@@ -125,12 +129,14 @@ Restarts the project containers by stopping and then starting them. Useful for a
 
 ```sh
 cd /path/to/workspace
-act restart [-p <project_name>] [-b] [-vb]
+act restart [-p <project_name>] [-b] [-vb] [--app | --dep]
 ```
 
 - `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
 - `-b`, `--build`: Rebuild containers when composing up (after stopping them).
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
+- `--app`: Only operate on application containers (docker-compose.yml). Mutually exclusive with --dep.
+- `--dep`: Only operate on dependency containers (docker-compose-dependencies.yml). Mutually exclusive with --app.
 
 **Examples:**
 
@@ -144,6 +150,18 @@ Restart with verbose output:
 
 ```sh
 act restart -b -vb
+```
+
+Restart only application containers:
+
+```sh
+act restart --app
+```
+
+Restart only dependency containers with rebuild:
+
+```sh
+act restart --dep -b
 ```
 
 #### Initialize a Project

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import patch
+from arches_containers.main import main
+import sys
+
+# Helper to simulate CLI arguments
+def run_cli(args):
+    sys.argv = ["arches-containers"] + args
+    try:
+        main()
+    except SystemExit:
+        pass
+
+def test_restart_runs_down_and_up():
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        # Simulate active project
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        run_cli(["restart", "-p", "demo"])
+        # Should call down then up
+        assert mock_compose.call_count == 2
+        assert mock_compose.call_args_list[0][0][1] == "down"
+        assert mock_compose.call_args_list[1][0][1] == "up"
+
+def test_restart_with_build_and_verbose():
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        run_cli(["restart", "-p", "demo", "-b", "-vb"])
+        # Should call down (no build), then up (with build)
+        assert mock_compose.call_count == 2
+        assert mock_compose.call_args_list[0][0][2] is False  # build for down
+        assert mock_compose.call_args_list[1][0][2] is True   # build for up

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -1,7 +1,8 @@
-import pytest
+import subprocess
+import sys
+import os
 from unittest.mock import patch
 from arches_containers.main import main
-import sys
 
 # Helper to simulate CLI arguments
 def run_cli(args):
@@ -87,3 +88,41 @@ def test_down_with_dep_flag():
         # Should call down with dep container type
         assert mock_compose.call_count == 1
         assert mock_compose.call_args_list[0][0][4] == "dep"  # container_type
+
+def test_app_and_dep_flags_mutually_exclusive():
+    """Test that --app and --dep flags cannot be used together"""
+
+    
+    # Get the directory containing this test file, then go up one level to the package root
+    test_dir = os.path.dirname(os.path.abspath(__file__))
+    package_root = os.path.dirname(test_dir)
+    
+    # Test with restart command
+    result = subprocess.run([
+        sys.executable, "-m", "arches_containers.main", 
+        "restart", "-p", "demo", "--app", "--dep"
+    ], capture_output=True, text=True, cwd=package_root)
+    
+    # Should exit with error code (argparse error)
+    assert result.returncode != 0
+    assert "not allowed with argument" in result.stderr or "mutually exclusive" in result.stderr
+    
+    # Test with up command  
+    result = subprocess.run([
+        sys.executable, "-m", "arches_containers.main",
+        "up", "-p", "demo", "--app", "--dep"
+    ], capture_output=True, text=True, cwd=package_root)
+    
+    # Should exit with error code (argparse error)
+    assert result.returncode != 0
+    assert "not allowed with argument" in result.stderr or "mutually exclusive" in result.stderr
+    
+    # Test with down command
+    result = subprocess.run([
+        sys.executable, "-m", "arches_containers.main",
+        "down", "-p", "demo", "--app", "--dep"  
+    ], capture_output=True, text=True, cwd=package_root)
+    
+    # Should exit with error code (argparse error)
+    assert result.returncode != 0
+    assert "not allowed with argument" in result.stderr or "mutually exclusive" in result.stderr

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -37,3 +37,53 @@ def test_restart_with_build_and_verbose():
         assert mock_compose.call_count == 2
         assert mock_compose.call_args_list[0][0][2] is False  # build for down
         assert mock_compose.call_args_list[1][0][2] is True   # build for up
+
+def test_restart_with_app_flag():
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        run_cli(["restart", "-p", "demo", "--app"])
+        # Should call down then up with app container type
+        assert mock_compose.call_count == 2
+        assert mock_compose.call_args_list[0][0][4] == "app"  # container_type for down
+        assert mock_compose.call_args_list[1][0][4] == "app"  # container_type for up
+
+def test_restart_with_dep_flag():
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        run_cli(["restart", "-p", "demo", "--dep"])
+        # Should call down then up with dep container type
+        assert mock_compose.call_count == 2
+        assert mock_compose.call_args_list[0][0][4] == "dep"  # container_type for down
+        assert mock_compose.call_args_list[1][0][4] == "dep"  # container_type for up
+
+def test_up_with_app_flag():
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        run_cli(["up", "-p", "demo", "--app"])
+        # Should call up with app container type
+        assert mock_compose.call_count == 1
+        assert mock_compose.call_args_list[0][0][4] == "app"  # container_type
+
+def test_down_with_dep_flag():
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        run_cli(["down", "-p", "demo", "--dep"])
+        # Should call down with dep container type
+        assert mock_compose.call_count == 1
+        assert mock_compose.call_args_list[0][0][4] == "dep"  # container_type


### PR DESCRIPTION
This pull request adds a new `restart` command to the CLI for managing project containers, and enhances the existing `up` and `down` commands with options to target only application or dependency containers. It also improves the documentation and adds comprehensive tests for the new functionality.

**CLI Enhancements:**

* Added a `restart` command that stops and then starts project containers, with options to rebuild and control verbosity. The command supports mutually exclusive `--app` and `--dep` flags to restrict operations to application or dependency containers, respectively. (`arches_containers/main.py` [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR27-R52) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL89-R105) [[3]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL114-R145)
* Updated the `up` and `down` commands to also support the `--app` and `--dep` flags, allowing users to operate only on specific container groups. (`arches_containers/main.py` [arches_containers/main.pyR27-R52](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR27-R52))

**Core Functionality Updates:**

* Modified the `compose_project` function to accept a `container_type` argument, enabling selective control over which containers are started or stopped. The function now provides clearer output messages and only waits for project service availability when application containers are started. (`arches_containers/manage.py` [[1]](diffhunk://#diff-ff868c0428d1f2a764dfbbfe437a60a3c46fab738777eee4b4c92e2b9d5fdb0aL28-R47) [[2]](diffhunk://#diff-ff868c0428d1f2a764dfbbfe437a60a3c46fab738777eee4b4c92e2b9d5fdb0aL66-R80)

**Documentation Improvements:**

* Expanded the `readme.md` to document the new `restart` command and the usage of `--app` and `--dep` flags for `up`, `down`, and `restart`. Provided usage examples for various scenarios. (`readme.md` [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L104-R165) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R244)

**Testing:**

* Added a new test module `tests/test_restart.py` to verify the correct behavior of the `restart`, `up`, and `down` commands, including flag handling and command sequencing. (`tests/test_restart.py` [tests/test_restart.pyR1-R89](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cR1-R89))

**Other Minor Changes:**

* Made small formatting and documentation improvements in `readme.md`. (`readme.md`)[[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R27) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L298-R353)