### PR TITLE
act up handle arches cloning

### DIFF
--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.0.0"
+AC_VERSION = "1.0.1a"

--- a/arches_containers/utils/arches_repo_helper.py
+++ b/arches_containers/utils/arches_repo_helper.py
@@ -27,6 +27,11 @@ def clone_and_checkout_repo(project_name, verbose=False):
 
 def change_arches_branch(project_name, verbose=False):
     ac_project, repo_url, clone_dir, branch = _get_repo_info(project_name)
+
+    # check the arches repo exists
+    if not os.path.exists(clone_dir):
+        clone_and_checkout_repo(project_name, verbose)
+
     os.chdir(clone_dir)
     result = subprocess.run(
         ["git", "checkout", branch],

--- a/arches_containers/utils/arches_repo_helper.py
+++ b/arches_containers/utils/arches_repo_helper.py
@@ -31,6 +31,7 @@ def change_arches_branch(project_name, verbose=False):
     # check the arches repo exists
     if not os.path.exists(clone_dir):
         clone_and_checkout_repo(project_name, verbose)
+        return
 
     os.chdir(clone_dir)
     result = subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.0.0"
+version = "1.0.1a"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Supports Arches 6.1 to 8.0 (current development version)."
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }


### PR DESCRIPTION
fixes #67 

This pull request introduces a minor version bump to the `arches-containers` project, along with an improvement to the repository branch switching logic. The most notable change is the addition of a check to ensure the Arches repository exists before attempting to switch branches, which improves reliability when working with project repositories.

Version update:

* Updated the version from `1.0.0` to `1.0.1a` in both `arches_containers/__init__.py` and `pyproject.toml` to reflect the new release. [[1]](diffhunk://#diff-43f48e97d0ff2e864b101939e296d742da6b548c9656fbe00d7a02c72349c065L1-R1) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R7)

Repository management improvement:

* In `arches_containers/utils/arches_repo_helper.py`, added a check in `change_arches_branch` to clone and checkout the repository if it does not already exist before switching branches. This prevents errors when the repository directory is missing.