### PR TITLE
Add development stage to Dockerfiles and update docker-compose files …

### DIFF
--- a/arches_containers/template/_7.6_/Dockerfile
+++ b/arches_containers/template/_7.6_/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.8
+FROM python:3.11.8 AS base
 USER root
 
 ## Build Args
@@ -109,3 +109,18 @@ CMD ["run_arches"]
 
 # Expose port 8000
 EXPOSE 8000
+
+# Dev stage: extends base and installs the Arches project package.
+# This stage is used by docker-compose.yml for the dev server.
+# Requires the project directory to exist on disk (i.e. act init must have been run first).
+FROM base AS dev
+
+# Re-declare build args — ARGs do not persist across stages
+ARG PROJ_NAME=project
+ARG PROJ_REPO_NAME={{project_repo_directory}}
+
+# Copy the project source from the build context (workspace root)
+COPY ${PROJ_REPO_NAME}/ ${WEB_ROOT}/${PROJ_NAME}/
+
+# Install the project as an editable package so Django can import it
+RUN pip install -e ${WEB_ROOT}/${PROJ_NAME}

--- a/arches_containers/template/_7.6_/docker-compose-init.yml
+++ b/arches_containers/template/_7.6_/docker-compose-init.yml
@@ -2,7 +2,7 @@
 services:
     {{project_urlsafe}}-{{project_hash}}:
       container_name: {{project_urlsafe}}-{{project_hash}}
-      image: he/{{project}}-{{project_hash}}:dev_build
+      image: he/{{project}}-{{project_hash}}:base
       build:
         args:
           - "PROJ_NAME={{project}}"
@@ -10,6 +10,7 @@ services:
           - "DOCKER_PATH=./.arches_containers/{{project}}/docker"
         context: ../..
         dockerfile: ./.arches_containers/{{project}}/Dockerfile
+        target: base
       command: create_project
       volumes:
         - ../..:/web_root

--- a/arches_containers/template/_7.6_/docker-compose.yml
+++ b/arches_containers/template/_7.6_/docker-compose.yml
@@ -10,6 +10,7 @@ services:
           - "DOCKER_PATH=./.arches_containers/{{project}}/docker"
         context: ../..
         dockerfile: ./.arches_containers/{{project}}/Dockerfile
+        target: dev
       command: run_arches
       volumes:
         - ../../arches:/web_root/arches

--- a/arches_containers/template/_8.0_/Dockerfile
+++ b/arches_containers/template/_8.0_/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm
+FROM python:3.13-slim-bookworm AS base
 USER root
 
 ## Build Args
@@ -99,3 +99,18 @@ CMD ["run_arches"]
 
 # Expose port 8000
 EXPOSE 8000
+
+# Dev stage: extends base and installs the Arches project package.
+# This stage is used by docker-compose.yml for the dev server.
+# Requires the project directory to exist on disk (i.e. act init must have been run first).
+FROM base AS dev
+
+# Re-declare build args — ARGs do not persist across stages
+ARG PROJ_NAME={{project}}
+ARG PROJ_REPO_NAME={{project_repo_directory}}
+
+# Copy the project source from the build context (workspace root)
+COPY ${PROJ_REPO_NAME}/ ${WEB_ROOT}/${PROJ_NAME}/
+
+# Install the project as an editable package so Django can import it
+RUN pip install -e ${WEB_ROOT}/${PROJ_NAME}

--- a/arches_containers/template/_8.0_/docker-compose-init.yml
+++ b/arches_containers/template/_8.0_/docker-compose-init.yml
@@ -2,7 +2,7 @@
 services:
     {{project_urlsafe}}-{{project_hash}}:
       container_name: {{project_urlsafe}}-{{project_hash}}
-      image: he/{{project}}-{{project_hash}}:dev_build
+      image: he/{{project}}-{{project_hash}}:base
       build:
         args:
           - "PROJ_NAME={{project}}"
@@ -10,6 +10,7 @@ services:
           - "DOCKER_PATH=./.arches_containers/{{project}}/docker"
         context: ../..
         dockerfile: ./.arches_containers/{{project}}/Dockerfile
+        target: base
       command: create_project
       volumes:
         - ../..:/web_root

--- a/arches_containers/template/_8.0_/docker-compose.yml
+++ b/arches_containers/template/_8.0_/docker-compose.yml
@@ -10,6 +10,7 @@ services:
           - "DOCKER_PATH=./.arches_containers/{{project}}/docker"
         context: ../..
         dockerfile: ./.arches_containers/{{project}}/Dockerfile
+        target: dev
       command: run_arches
       volumes:
         - ../../arches:/web_root/arches


### PR DESCRIPTION
This fixes an issue where exisitng project won't run as they don't get installed as done with the startproject command

This pull request refactors the Docker build process for both the 7.6 and 8.0 Arches container templates by introducing multi-stage builds with explicit `base` and `dev` stages. It updates the Dockerfiles and associated docker-compose files to use these new stages, improving build clarity and separation between initialization and development environments.

**Dockerfile multi-stage build improvements:**

* Refactored both `Dockerfile`s (`_7.6_` and `_8.0_`) to introduce a `base` stage for shared setup and a `dev` stage for development, which installs the project in editable mode for Django imports. [[1]](diffhunk://#diff-e5b196fe223705cb4493fb36f2f0bb5c3af4f950336358c55a784f05112140dbL1-R1) [[2]](diffhunk://#diff-90e754d042867efd67b18ad249a1ec07d2022b23eae754ad805b3945ce5d9893L1-R1) [[3]](diffhunk://#diff-e5b196fe223705cb4493fb36f2f0bb5c3af4f950336358c55a784f05112140dbR112-R126) [[4]](diffhunk://#diff-90e754d042867efd67b18ad249a1ec07d2022b23eae754ad805b3945ce5d9893R102-R116)

**docker-compose configuration updates:**

* Updated `docker-compose.yml` to explicitly build and run the `dev` stage for the development server, ensuring the project is installed in editable mode for local development. [[1]](diffhunk://#diff-f3349203eec9f8b09db14539a4402e7688cf44b324ecbb56d4b1dea0fd687590R13) [[2]](diffhunk://#diff-2218fa77db1a38aabfe64a5e4906a30d8de04f5dcef6e386fa66d4df678bbae9R13)
* Updated `docker-compose-init.yml` to build and run the `base` stage for project initialization, aligning the image and build target with the new Dockerfile structure.

These changes make the container setup more modular and better suited for both initialization and development workflows.

Completes #74 