### PR TITLE
remove init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,20 +61,12 @@ act [OPTIONS] COMMAND [ARGS]...
     This creates the arches-container project configuration and sets it as the active project.
 
     ```sh
-    act create -p my_project -v 7.5 --activate
-    ```
-
-1. Initialize the project:
-
-    This sets up the Arches repo, builds the development container, and creates the Arches project directory.
-
-    ```sh
-    act init
+    act create -p my_project -v 8.0 --activate
     ```
 
 1. Start the project:
 
-    This starts the containers and the Arches development server.
+    This sets up the Arches repo, runs initialisation if needed, then starts the containers and the Arches development server.
 
     ```sh
     act up
@@ -166,16 +158,6 @@ Restart only dependency containers with rebuild:
 ```sh
 act restart --dep -b
 ```
-
-#### Initialize a Project
-
-```sh
-cd /path/to/workspace
-act init [-p <project_name>] [-vb]
-```
-
-- `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
-- `-vb`, `--verbose`: Print verbose output during the compose processes.
 
 #### Activate a Project
 
@@ -324,9 +306,9 @@ The project configuration file `config.json` is used to store default values for
   "project_name": "arches_her_project",
   "project_name_url_safe": "archesherproject",
   "project_repo_directory": "arches-her-project",
-    "arches_version": "7.5",
+    "arches_version": "8.0",
     "arches_repo_organization": "archesproject",
-    "arches_repo_branch": "dev/7.5.x"
+    "arches_repo_branch": "stable/8.0.0"
 }
 ```
 

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -34,7 +34,7 @@ def main():
     
 
     # Sub-parser for starting containers
-    parser_up = subparsers.add_parser("up", help="Start the project containers", formatter_class=parser.formatter_class)
+    parser_up = subparsers.add_parser("up", help="Start the project containers. Initialises automatically if needed.", formatter_class=parser.formatter_class)
     parser_up.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
     parser_up.add_argument("-b", "--build", action="store_true", help="Rebuild containers when composing up")
     parser_up.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
@@ -58,11 +58,6 @@ def main():
     container_group_restart = parser_restart.add_mutually_exclusive_group()
     container_group_restart.add_argument("--app", action="store_true", help="Only operate on application containers (docker-compose.yml)")
     container_group_restart.add_argument("--dep", action="store_true", help="Only operate on dependency containers (docker-compose-dependencies.yml)")
-
-    # Sub-parser for initializing project
-    parser_init = subparsers.add_parser("init", help="Initialize the project", formatter_class=parser.formatter_class)
-    parser_init.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
-    parser_init.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
 
     # Sub-parser for activating project
     parser_activate = subparsers.add_parser("activate", help="Set a project as the active project", formatter_class=parser.formatter_class)
@@ -127,7 +122,7 @@ def main():
             if not _is_version_supported(args.version):
                 AcOutputManager.warn(f"Arches version {args.version} is no longer actively maintained, so this template may not work as expected and need manual adjustments to fix.")
     # ========================================================================================================
-    elif args.command in ["up", "down", "init", "activate", "restart"]:
+    elif args.command in ["up", "down", "activate", "restart"]:
         if args.project_name == "" and args.command != "activate":
             try:
                 args.project_name = ac_settings.get_active_project().project_name
@@ -154,11 +149,15 @@ def main():
                 ac_settings.set_active_project(args.project_name)
                 arches_repo_helper.clone_and_checkout_repo(args.project_name, verbose=args.verbose)
                 AcOutputManager.complete_step(f"Project '{args.project_name}' set as active.")
-            elif args.command == "init":
+            elif args.command == "up":
                 arches_repo_helper.clone_and_checkout_repo(args.project_name, verbose=args.verbose)
-                initialize_project(args.project_name, args.verbose)
+                if not ac_project.is_initialised():
+                    initialize_project(args.project_name, args.verbose)
+                # Determine container type
+                container_type = "app" if getattr(args, 'app', False) else "dep" if getattr(args, 'dep', False) else "both"
+                compose_project(args.project_name, "up", getattr(args, 'build', False), args.verbose, container_type)
             elif args.command == "restart":
-                arches_repo_helper.change_arches_branch(args.project_name, verbose=args.verbose)
+                arches_repo_helper.clone_and_checkout_repo(args.project_name, verbose=args.verbose)
                 # Determine container type
                 container_type = "app" if getattr(args, 'app', False) else "dep" if getattr(args, 'dep', False) else "both"
                 # First bring containers down
@@ -166,10 +165,9 @@ def main():
                 # Then bring them up, with build if requested
                 compose_project(args.project_name, "up", getattr(args, 'build', False), args.verbose, container_type)
             else:
-                arches_repo_helper.change_arches_branch(args.project_name, verbose=args.verbose)
-                # Determine container type
+                # down
                 container_type = "app" if getattr(args, 'app', False) else "dep" if getattr(args, 'dep', False) else "both"
-                compose_project(args.project_name, args.command, getattr(args, 'build', False), args.verbose, container_type)
+                compose_project(args.project_name, "down", False, args.verbose, container_type)
 
     # ========================================================================================================
     elif args.command == "list":

--- a/arches_containers/manage.py
+++ b/arches_containers/manage.py
@@ -27,6 +27,31 @@ def test_project_service_available_with_status_200(project_name) -> bool:
     )
     return result.returncode == 0 and result.stdout.strip() == "200"
 
+def _image_build_needed(compose_file_path, project_path):
+    '''
+    Return True if any image referenced by the compose file does not exist locally
+    (i.e. it will need to be built or pulled before containers can start).
+    '''
+    try:
+        config_result = subprocess.run(
+            ["docker", "compose", "-f", compose_file_path, "config", "--images"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+            cwd=project_path
+        )
+        for image in config_result.stdout.splitlines():
+            image = image.strip()
+            if image:
+                inspect = subprocess.run(
+                    ["docker", "image", "inspect", image],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                )
+                if inspect.returncode != 0:
+                    return True
+    except Exception:
+        pass
+    return False
+
+
 def compose_project(project_name, action="up", build=False, verbose=False, container_type="both"):
     '''
     Compose the project using docker-compose.yml and docker-compose-dependencies.yml files.
@@ -61,6 +86,11 @@ def compose_project(project_name, action="up", build=False, verbose=False, conta
             subprocess.run(["sleep", "15"])
 
         compose_file_path = os.path.join(project_path, compose_file)
+
+        if compose_file == DOCKER_COMPOSE_FILE and action == "up":
+            if build or _image_build_needed(compose_file_path, project_path):
+                AcOutputManager.write("... ℹ️ the development image needs to be built and may take a few minutes.")
+
         command = ["docker", "compose", "-f", compose_file_path, action]
         if action == "up":
             command.append("-d")

--- a/arches_containers/utils/workspace.py
+++ b/arches_containers/utils/workspace.py
@@ -144,6 +144,11 @@ class AcProject:
             return ""
         return self._config.get(AcProjectAttributes.PROJECT_HASH.value, "")
 
+    def is_initialised(self) -> bool:
+        ac_workspace = AcWorkspace()
+        repo_dir = os.path.join(ac_workspace.path, self[AcProjectAttributes.PROJECT_REPO_DIRECTORY.value])
+        return os.path.exists(repo_dir)
+
 class AcSettings:
     '''
     Provides access to the settings for the workspace.

--- a/arches_containers/utils/workspace.py
+++ b/arches_containers/utils/workspace.py
@@ -146,7 +146,11 @@ class AcProject:
 
     def is_initialised(self) -> bool:
         ac_workspace = AcWorkspace()
-        repo_dir = os.path.join(ac_workspace.path, self[AcProjectAttributes.PROJECT_REPO_DIRECTORY.value])
+        repo_dir_name = self._config.get(
+            AcProjectAttributes.PROJECT_REPO_DIRECTORY.value,
+            self.project_name,
+        )
+        repo_dir = os.path.join(ac_workspace.path, repo_dir_name)
         return os.path.exists(repo_dir)
 
 class AcSettings:
@@ -604,7 +608,7 @@ class AcWorkspace:
                 selected_hash = _normalize_and_validate_project_hash(target_hash)
             elif new_hash is True:
                 selected_hash = _generate_new_project_hash(current_hash)
-            elif new_hash is None:
+            elif new_hash is None and current_hash:
                 if self._confirm(
                     "Generate a new hash for this import? Keeping the existing hash can overwrite another working environment using the same Docker resource names. (y/n): ",
                     prompt_default,

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -10,6 +10,7 @@
 - Fixes an issue with the service startup check incorrectly thinking the project service was available [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
 - Fixes webpack container running front end build before the project service is available [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
 - Removes the `init` command — initialisation is now performed automatically by `up` when a project has not yet been initialised [#87](https://github.com/HistoricEngland/arches-containers/pull/87).
+- Adds warnings when creating templates for  unsupportedarches versions [#85](https://github.com/HistoricEngland/arches-containers/pull/85).
 
 
 ## Installation Instructions

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -9,6 +9,7 @@
 - Adds a hash to project files to allow for multiple projects with the same name [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
 - Fixes an issue with the service startup check incorrectly thinking the project service was available [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
 - Fixes webpack container running front end build before the project service is available [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
+- Removes the `init` command — initialisation is now performed automatically by `up` when a project has not yet been initialised [#87](https://github.com/HistoricEngland/arches-containers/pull/87).
 
 
 ## Installation Instructions

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -14,7 +14,7 @@ def run_cli(args):
 
 def test_restart_runs_down_and_up():
     with patch("arches_containers.main.compose_project") as mock_compose, \
-         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_branch, \
          patch("arches_containers.main.AcWorkspace") as mock_workspace, \
          patch("arches_containers.main.AcOutputManager"):
         # Simulate active project
@@ -28,7 +28,7 @@ def test_restart_runs_down_and_up():
 
 def test_restart_with_build_and_verbose():
     with patch("arches_containers.main.compose_project") as mock_compose, \
-         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_branch, \
          patch("arches_containers.main.AcWorkspace") as mock_workspace, \
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
@@ -41,7 +41,7 @@ def test_restart_with_build_and_verbose():
 
 def test_restart_with_app_flag():
     with patch("arches_containers.main.compose_project") as mock_compose, \
-         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_branch, \
          patch("arches_containers.main.AcWorkspace") as mock_workspace, \
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
@@ -54,7 +54,7 @@ def test_restart_with_app_flag():
 
 def test_restart_with_dep_flag():
     with patch("arches_containers.main.compose_project") as mock_compose, \
-         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_branch, \
          patch("arches_containers.main.AcWorkspace") as mock_workspace, \
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
@@ -67,11 +67,12 @@ def test_restart_with_dep_flag():
 
 def test_up_with_app_flag():
     with patch("arches_containers.main.compose_project") as mock_compose, \
-         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_branch, \
          patch("arches_containers.main.AcWorkspace") as mock_workspace, \
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
         mock_settings.get_active_project.return_value.project_name = "demo"
+        mock_workspace.return_value.get_project.return_value.is_initialised.return_value = True
         run_cli(["up", "-p", "demo", "--app"])
         # Should call up with app container type
         assert mock_compose.call_count == 1
@@ -79,7 +80,7 @@ def test_up_with_app_flag():
 
 def test_down_with_dep_flag():
     with patch("arches_containers.main.compose_project") as mock_compose, \
-         patch("arches_containers.main.arches_repo_helper.change_arches_branch") as mock_branch, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_branch, \
          patch("arches_containers.main.AcWorkspace") as mock_workspace, \
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
@@ -88,6 +89,38 @@ def test_down_with_dep_flag():
         # Should call down with dep container type
         assert mock_compose.call_count == 1
         assert mock_compose.call_args_list[0][0][4] == "dep"  # container_type
+
+def test_up_uninitialised_project_runs_init():
+    """Assert that when is_initialised() returns False, clone_and_checkout_repo and initialize_project are both called."""
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_clone, \
+         patch("arches_containers.main.initialize_project") as mock_init, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        mock_workspace.return_value.get_project.return_value.is_initialised.return_value = False
+        run_cli(["up", "-p", "demo"])
+        mock_clone.assert_called_once()
+        mock_init.assert_called_once()
+        mock_compose.assert_called_once()
+
+
+def test_up_initialised_project_skips_init():
+    """Assert that when is_initialised() returns True, initialize_project is not called."""
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo") as mock_clone, \
+         patch("arches_containers.main.initialize_project") as mock_init, \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager"):
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        mock_workspace.return_value.get_project.return_value.is_initialised.return_value = True
+        run_cli(["up", "-p", "demo"])
+        mock_clone.assert_called_once()
+        mock_init.assert_not_called()
+        mock_compose.assert_called_once()
+
 
 def test_app_and_dep_flags_mutually_exclusive():
     """Test that --app and --dep flags cannot be used together"""

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -150,6 +150,28 @@ class TestAcWorkspace:
         imported_hash = workspace.get_project(project_name).get_project_hash()
         assert imported_hash != original_hash
 
+    def test_import_project_does_not_prompt_when_config_has_no_hash_key(self, temp_workspace, tmp_path, monkeypatch):
+        """Importing a config without a project_hash key should not prompt for a new hash."""
+        project_name = "test_project"
+        temp_workspace.create_project(project_name, make_create_args())
+        repo_path = tmp_path / "test_repo_no_hash_key"
+        repo_path.mkdir()
+
+        temp_workspace.export_project(project_name, str(repo_path))
+        temp_workspace.delete_project(project_name)
+
+        # Remove the project_hash key from the exported config to simulate a legacy config
+        ac_repo_path = os.path.join(repo_path, f".ac_{project_name}")
+        config_path = os.path.join(ac_repo_path, "config.json")
+        with open(config_path, "r") as f:
+            config = json.load(f)
+        config.pop(AcProjectAttributes.PROJECT_HASH.value, None)
+        with open(config_path, "w") as f:
+            json.dump(config, f, indent=4)
+
+        monkeypatch.setattr("builtins.input", lambda _: (_ for _ in ()).throw(AssertionError("input() should not be called for configs without a project_hash key")))
+        temp_workspace.import_project(project_name, str(repo_path))
+
     def test_export_project_keeps_existing_repo_hash(self, workspace_with_project, tmp_path, monkeypatch):
         workspace, project_name = workspace_with_project
         repo_path = tmp_path / "test_repo_keep_hash"

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -308,6 +308,19 @@ class TestAcProject:
         reloaded = temp_workspace.get_project(project_name)
         assert reloaded.get_project_hash() == ""
 
+    def test_is_initialised_returns_false_when_repo_dir_missing(self, workspace_with_project):
+        workspace, project_name = workspace_with_project
+        project = workspace.get_project(project_name)
+        # repo_dir does not exist in workspace root, so is_initialised() should return False
+        assert project.is_initialised() is False
+
+    def test_is_initialised_returns_true_when_repo_dir_exists(self, workspace_with_project):
+        workspace, project_name = workspace_with_project
+        project = workspace.get_project(project_name)
+        repo_dir = os.path.join(workspace.path, project[AcProjectAttributes.PROJECT_REPO_DIRECTORY.value])
+        os.makedirs(repo_dir, exist_ok=True)
+        assert project.is_initialised() is True
+
 class TestGenerateProjectHash:
     def test_hash_is_five_chars(self):
         h = _generate_project_hash("/some/path/to/project")


### PR DESCRIPTION
Completes #80

This pull request refactors the workflow for project initialization and container management in the Arches Containers CLI, simplifying the user experience by making the `up` command automatically handle initialization if needed. It also removes the now-unnecessary `init` command from both the CLI and documentation, updates default versions, and adds robust tests for the new behavior.

**Streamlined Project Initialization and Container Management:**

* The `up` command now checks if the project is initialized and runs the initialization steps automatically if required, eliminating the need for a separate `init` command. The CLI, help text, and documentation have all been updated to reflect this change. (`arches_containers/main.py`, `README.md`) [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL37-R37) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL62-L66) [[3]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL130-R125) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R69) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-L179)
* The `init` subparser and related logic have been removed from the codebase, as initialization is now handled by the `up` command. (`arches_containers/main.py`, `README.md`) [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL62-L66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-L179)

**Improvements to Project State Detection:**

* A new `is_initialised()` method has been added to the project class to determine if the project repository directory exists, which is used to decide whether initialization is needed. (`arches_containers/utils/workspace.py`)

**Documentation and Defaults Updates:**

* The default Arches version and branch have been updated from 7.5/dev/7.5.x to 8.0/stable/8.0.0 in both the code and documentation. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R69) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L327-R311)

**Testing Enhancements:**

* Tests have been updated and expanded to cover the new initialization logic, ensuring that `up` runs initialization only when necessary and that the correct repository methods are called. New tests for `is_initialised()` have also been added. (`tests/test_restart.py`, `tests/test_workspace.py`) [[1]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL17-R17) [[2]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL31-R31) [[3]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL44-R44) [[4]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL57-R57) [[5]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL70-R83) [[6]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cR93-R124) [[7]](diffhunk://#diff-8d854b776c003a20074b72eaefda9a05da3b88262dc4bb340f88b4c45613fc73R311-R323)