### PR TITLE
Add shell and logs commands for container interaction and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,72 @@ cd /path/to/workspace
 act status
 ```
 
+### Open a Shell in a Container
+
+Opens an interactive bash shell inside a project container. Defaults to the main application container.
+
+```sh
+cd /path/to/workspace
+act shell [-p <project_name>] [-c <container_name>] [--exec "<command>"]
+```
+
+- `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
+- `-c`, `--container`: The name of the container to open a shell in. Defaults to the main application container.
+- `--exec`: A command to run in the container non-interactively instead of opening a shell. Useful for scripting. Value should be between quotes.
+
+**Examples:**
+
+Open an interactive shell in the default container:
+
+```sh
+act shell
+```
+
+Open a shell in a specific container:
+
+```sh
+act shell -c my-project-db
+```
+
+Run a one-off command non-interactively (exit code is propagated):
+
+```sh
+act shell --exec "python manage.py show_graphs"
+```
+
+### View Container Logs
+
+Shows logs for a project container. Defaults to the main application container.
+
+```sh
+cd /path/to/workspace
+act logs [-p <project_name>] [-c <container_name>] [-f]
+```
+
+- `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
+- `-c`, `--container`: The name of the container to show logs for. Defaults to the main application container.
+- `-f`, `--follow`: Follow the log output (like `docker logs -f`). Press Ctrl+C to stop.
+
+**Examples:**
+
+View logs of the default container:
+
+```sh
+act logs
+```
+
+Follow logs in real time:
+
+```sh
+act logs -f
+```
+
+View logs of a specific container:
+
+```sh
+act logs -c my-project-db
+```
+
 ### Quickly open the application in a browser
 
 Steps to open the application in a browser.

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -4,7 +4,7 @@ import os
 import webbrowser
 from slugify import slugify
 from arches_containers import AC_VERSION as arches_containers_version
-from arches_containers.manage import compose_project, initialize_project, status
+from arches_containers.manage import compose_project, initialize_project, status, shell_container, logs_container
 import arches_containers.utils.arches_repo_helper as arches_repo_helper
 from arches_containers.utils.workspace import AcWorkspace, AcSettings, AcProject, AcProjectAttributes, _is_version_supported
 from arches_containers.utils.create_launch_config import generate_launch_config
@@ -101,6 +101,18 @@ def main():
 
     # Sub-parser for the status command
     parser_status = subparsers.add_parser("status", help="Check container status", formatter_class=parser.formatter_class)
+
+    # Sub-parser for the shell command
+    parser_shell = subparsers.add_parser("shell", help="Open an interactive shell in a project container", formatter_class=parser.formatter_class)
+    parser_shell.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
+    parser_shell.add_argument("-c", "--container", default=None, help="The name of the container to open a shell in. Defaults to the main application container.")
+    parser_shell.add_argument("--exec", dest="exec_cmd", default=None, help="A command to run in the container instead of opening an interactive shell. Useful for scripting.")
+
+    # Sub-parser for the logs command
+    parser_logs = subparsers.add_parser("logs", help="Show logs for a project container", formatter_class=parser.formatter_class)
+    parser_logs.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
+    parser_logs.add_argument("-c", "--container", default=None, help="The name of the container to show logs for. Defaults to the main application container.")
+    parser_logs.add_argument("-f", "--follow", action="store_true", help="Follow the log output.")
 
     # Sub-parser for the view command
     parser_view = subparsers.add_parser("view", help="View the active project in a web browser", formatter_class=parser.formatter_class)
@@ -250,6 +262,28 @@ def main():
         with AcOutputManager("Checking active project container status") as spinner:
             AcOutputManager.write("▶️  Checking active project container status")
             status()
+
+    # ========================================================================================================
+    elif args.command == "shell":
+        if args.project_name == "":
+            try:
+                args.project_name = ac_settings.get_active_project().project_name
+            except Exception as e:
+                AcOutputManager.fail("No project name passed and no active project set. Run 'arches-containers create' to create a new project.")
+        result_code = shell_container(args.project_name, container=args.container, exec_cmd=args.exec_cmd)
+        if result_code != 0:
+            exit(result_code)
+
+    # ========================================================================================================
+    elif args.command == "logs":
+        if args.project_name == "":
+            try:
+                args.project_name = ac_settings.get_active_project().project_name
+            except Exception as e:
+                AcOutputManager.fail("No project name passed and no active project set. Run 'arches-containers create' to create a new project.")
+        result_code = logs_container(args.project_name, container=args.container, follow=args.follow)
+        if result_code != 0:
+            exit(result_code)
 
     # ========================================================================================================
     elif args.command == "view":

--- a/arches_containers/manage.py
+++ b/arches_containers/manage.py
@@ -1,6 +1,6 @@
 import os, sys
 import subprocess
-from time import sleep
+from time import sleep, time
 from arches_containers.utils.workspace import AcWorkspace, AcSettings, AcProject
 import arches_containers.utils.arches_repo_helper as arches_repo_helper
 from arches_containers.utils.logger import AcOutputManager
@@ -180,6 +180,85 @@ def status():
         project_name = active_project.project_name
         project_name_urlsafe = active_project["project_name_url_safe"]
         get_running_containers(project_name, project_name_urlsafe)
+
+
+def _get_default_container_name(project_name):
+    '''
+    Returns the default container name for a project (the main application container).
+    '''
+    project = AcWorkspace().get_project(project_name)
+    project_hash = project.get_project_hash()
+    if project_hash:
+        return f"{project['project_name_url_safe']}-{project_hash}"
+    return project["project_name_url_safe"]
+
+
+def _check_container_running(container_name):
+    '''
+    Returns True if the container is running, False if it exists but is stopped,
+    or None if no container with that name exists.
+    '''
+    result = subprocess.run(
+        ["docker", "inspect", "--format", "{{.State.Running}}", container_name],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() == "true"
+
+
+def shell_container(project_name, container=None, exec_cmd=None):
+    '''
+    Open an interactive shell or run a command in a project container.
+    '''
+    container_name = container if container else _get_default_container_name(project_name)
+    running = _check_container_running(container_name)
+    if running is None:
+        AcOutputManager.fail(f"Container '{container_name}' not found. Is the project running? Try 'act up'.")
+        return 1
+    if not running:
+        AcOutputManager.fail(f"Container '{container_name}' is not running. Start it with 'act up'.")
+        return 1
+    if exec_cmd:
+        command = ["docker", "exec", container_name, "sh", "-c", exec_cmd]
+    else:
+        AcOutputManager.write(f"... Opening shell in container '{container_name}'.")
+        AcOutputManager.write("... ℹ️ Type 'exit' or press Ctrl+D to return to the terminal.")
+        command = ["docker", "exec", "-it", container_name, "/bin/bash"]
+    AcOutputManager.stop_spinner()
+    result = subprocess.run(command)
+    return result.returncode
+
+
+def logs_container(project_name, container=None, follow=False):
+    '''
+    Show logs for a project container.
+    '''
+    container_name = container if container else _get_default_container_name(project_name)
+    running = _check_container_running(container_name)
+    if running is None:
+        AcOutputManager.fail(f"Container '{container_name}' not found. Is the project running? Try 'act up'.")
+        return 1
+    if not running:
+        if follow:
+            AcOutputManager.fail(f"Container '{container_name}' is not running. Start it with 'act up'.")
+            return 1
+        else:
+            AcOutputManager.warn(f"Container '{container_name}' is not running — showing last known logs.")
+    command = ["docker", "logs", container_name]
+    if follow:
+        AcOutputManager.write(f"... Following logs for container '{container_name}'.")
+        AcOutputManager.write("... ℹ️ Press Ctrl+C to stop and return to the terminal.")
+
+        # pause for 3 seconds to give the user a chance to read the message before the logs start streaming
+        sleep(3)
+        command.append("-f")
+    AcOutputManager.stop_spinner()
+    try:
+        result = subprocess.run(command)
+    except KeyboardInterrupt:
+        return 0
+    return result.returncode
 
 def main(project_name=None, action="up", build=False, verbose=False):
     ac_workspace = AcWorkspace()

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -11,6 +11,8 @@
 - Fixes webpack container running front end build before the project service is available [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
 - Removes the `init` command — initialisation is now performed automatically by `up` when a project has not yet been initialised [#87](https://github.com/HistoricEngland/arches-containers/pull/87).
 - Adds warnings when creating templates for  unsupportedarches versions [#85](https://github.com/HistoricEngland/arches-containers/pull/85).
+- Adds a `shell` command to open an interactive shell inside a project container, with a `--exec` option for running non-interactive commands from scripts [#88](https://github.com/HistoricEngland/arches-containers/issues/88).
+- Adds a `logs` command to view container logs, with a `--follow`/`-f` option to stream output in real time [#89](https://github.com/HistoricEngland/arches-containers/issues/89).
 
 
 ## Installation Instructions

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -11,8 +11,8 @@
 - Fixes webpack container running front end build before the project service is available [#83](https://github.com/HistoricEngland/arches-containers/pull/83).
 - Removes the `init` command — initialisation is now performed automatically by `up` when a project has not yet been initialised [#87](https://github.com/HistoricEngland/arches-containers/pull/87).
 - Adds warnings when creating templates for  unsupportedarches versions [#85](https://github.com/HistoricEngland/arches-containers/pull/85).
-- Adds a `shell` command to open an interactive shell inside a project container, with a `--exec` option for running non-interactive commands from scripts [#88](https://github.com/HistoricEngland/arches-containers/issues/88).
-- Adds a `logs` command to view container logs, with a `--follow`/`-f` option to stream output in real time [#89](https://github.com/HistoricEngland/arches-containers/issues/89).
+- Adds a `shell` command to open an interactive shell inside a project container, with a `--exec` option for running non-interactive commands from scripts [#90](https://github.com/HistoricEngland/arches-containers/pull/90).
+- Adds a `logs` command to view container logs, with a `--follow`/`-f` option to stream output in real time [#90](https://github.com/HistoricEngland/arches-containers/pull/90).
 
 
 ## Installation Instructions

--- a/tests/test_shell_logs.py
+++ b/tests/test_shell_logs.py
@@ -1,0 +1,175 @@
+import pytest
+from unittest.mock import patch, MagicMock, call
+from arches_containers.manage import shell_container, logs_container
+
+
+@pytest.fixture
+def mock_project():
+    project = MagicMock()
+    project.__getitem__ = MagicMock(side_effect=lambda key: "my-project" if key == "project_name_url_safe" else None)
+    project.get_project_hash.return_value = "a1b2c"
+    return project
+
+
+@pytest.fixture
+def mock_workspace(mock_project):
+    with patch("arches_containers.manage.AcWorkspace") as mock_ws_cls:
+        mock_ws = MagicMock()
+        mock_ws.get_project.return_value = mock_project
+        mock_ws_cls.return_value = mock_ws
+        yield mock_ws_cls
+
+
+def _make_subprocess_side_effect(inspect_running: bool | None, exec_returncode: int = 0):
+    """
+    Returns a side_effect function for subprocess.run that:
+    - Responds to 'docker inspect' calls based on inspect_running
+      (None → returncode=1 meaning not found, True/False → returncode=0 with stdout 'true'/'false')
+    - Returns returncode=exec_returncode for all other docker commands
+    """
+    def side_effect(command, **kwargs):
+        result = MagicMock()
+        if "inspect" in command:
+            if inspect_running is None:
+                result.returncode = 1
+                result.stdout = ""
+            else:
+                result.returncode = 0
+                result.stdout = "true\n" if inspect_running else "false\n"
+        else:
+            result.returncode = exec_returncode
+        return result
+    return side_effect
+
+
+@pytest.fixture
+def mock_subprocess_running():
+    """subprocess.run where the container is running."""
+    with patch("arches_containers.manage.subprocess.run") as mock_run:
+        mock_run.side_effect = _make_subprocess_side_effect(inspect_running=True)
+        yield mock_run
+
+
+# ── shell_container ──────────────────────────────────────────────────────────
+
+class TestShellContainer:
+    def test_default_container_opens_interactive_bash(self, mock_subprocess_running, mock_workspace):
+        shell_container("my_project")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "exec", "-it", "my-project-a1b2c", "/bin/bash"]
+        )
+
+    def test_explicit_container_name_is_used(self, mock_subprocess_running, mock_workspace):
+        shell_container("my_project", container="custom-container")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "exec", "-it", "custom-container", "/bin/bash"]
+        )
+
+    def test_exec_cmd_produces_non_interactive_call(self, mock_subprocess_running, mock_workspace):
+        shell_container("my_project", exec_cmd="python manage.py show_graphs")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "exec", "my-project-a1b2c", "sh", "-c", "python manage.py show_graphs"]
+        )
+
+    def test_exec_cmd_with_explicit_container(self, mock_subprocess_running, mock_workspace):
+        shell_container("my_project", container="custom-container", exec_cmd="ls /app")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "exec", "custom-container", "sh", "-c", "ls /app"]
+        )
+
+    def test_returns_returncode(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=True, exec_returncode=1)
+            result = shell_container("my_project")
+        assert result == 1
+
+    def test_default_container_without_hash(self, mock_subprocess_running, mock_workspace, mock_project):
+        mock_project.get_project_hash.return_value = ""
+        result = shell_container("my_project")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "exec", "-it", "my-project", "/bin/bash"]
+        )
+        assert result == 0
+
+    def test_fails_when_container_not_found(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run, \
+             patch("arches_containers.manage.AcOutputManager") as mock_output:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=None)
+            shell_container("my_project")
+            mock_output.fail.assert_called_once()
+            assert "not found" in mock_output.fail.call_args[0][0]
+
+    def test_fails_when_container_stopped(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run, \
+             patch("arches_containers.manage.AcOutputManager") as mock_output:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=False)
+            shell_container("my_project")
+            mock_output.fail.assert_called_once()
+            assert "not running" in mock_output.fail.call_args[0][0]
+
+
+# ── logs_container ───────────────────────────────────────────────────────────
+
+class TestLogsContainer:
+    def test_default_container_shows_logs(self, mock_subprocess_running, mock_workspace):
+        logs_container("my_project")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "logs", "my-project-a1b2c"]
+        )
+
+    def test_follow_adds_flag(self, mock_subprocess_running, mock_workspace):
+        logs_container("my_project", follow=True)
+        mock_subprocess_running.assert_called_with(
+            ["docker", "logs", "my-project-a1b2c", "-f"]
+        )
+
+    def test_explicit_container_name_is_used(self, mock_subprocess_running, mock_workspace):
+        logs_container("my_project", container="custom-container")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "logs", "custom-container"]
+        )
+
+    def test_explicit_container_with_follow(self, mock_subprocess_running, mock_workspace):
+        logs_container("my_project", container="custom-container", follow=True)
+        mock_subprocess_running.assert_called_with(
+            ["docker", "logs", "custom-container", "-f"]
+        )
+
+    def test_returns_returncode(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=True, exec_returncode=1)
+            result = logs_container("my_project")
+        assert result == 1
+
+    def test_default_container_without_hash(self, mock_subprocess_running, mock_workspace, mock_project):
+        mock_project.get_project_hash.return_value = ""
+        result = logs_container("my_project")
+        mock_subprocess_running.assert_called_with(
+            ["docker", "logs", "my-project"]
+        )
+        assert result == 0
+
+    def test_fails_when_container_not_found(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run, \
+             patch("arches_containers.manage.AcOutputManager") as mock_output:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=None)
+            logs_container("my_project")
+            mock_output.fail.assert_called_once()
+            assert "not found" in mock_output.fail.call_args[0][0]
+
+    def test_fails_when_container_stopped_and_following(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run, \
+             patch("arches_containers.manage.AcOutputManager") as mock_output:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=False)
+            logs_container("my_project", follow=True)
+            mock_output.fail.assert_called_once()
+            assert "not running" in mock_output.fail.call_args[0][0]
+
+    def test_warns_and_proceeds_when_container_stopped(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run, \
+             patch("arches_containers.manage.AcOutputManager") as mock_output:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=False)
+            logs_container("my_project")
+        mock_output.warn.assert_called_once()
+        assert "not running" in mock_output.warn.call_args[0][0]
+        mock_run.assert_called_with(["docker", "logs", "my-project-a1b2c"])


### PR DESCRIPTION
Closes #88 #89

This pull request introduces two major new commands to the CLI tool: `shell` for opening an interactive shell or running commands inside a project container, and `logs` for viewing or following container logs. It also updates the documentation and release notes to reflect these new features, and adds comprehensive tests for both commands. These changes significantly improve the developer experience by making it easier to interact with and debug project containers.

**New CLI Features:**

* Added a `shell` command to open an interactive shell in a project container, with support for specifying the container, project, and running non-interactive commands via `--exec`. [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR105-R116) [[2]](diffhunk://#diff-ff868c0428d1f2a764dfbbfe437a60a3c46fab738777eee4b4c92e2b9d5fdb0aR184-R262)
* Added a `logs` command to view logs for a project container, with options to specify the container, project, and to follow logs in real time (`-f`). [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR105-R116) [[2]](diffhunk://#diff-ff868c0428d1f2a764dfbbfe437a60a3c46fab738777eee4b4c92e2b9d5fdb0aR184-R262)

**Implementation Details:**

* Implemented helper functions `_get_default_container_name` and `_check_container_running` in `manage.py` to support the new commands and handle container state checks robustly.

**Documentation and Release Notes:**

* Updated `README.md` with detailed usage instructions and examples for the new `shell` and `logs` commands.
* Updated `releases/1.1.0.md` to announce the addition of the `shell` and `logs` commands.

**Testing:**

* Added a new test module `tests/test_shell_logs.py` with thorough unit tests covering various scenarios for both `shell_container` and `logs_container`, including error handling and edge cases.