### PR TITLE
Consolidate dependabot dependency bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "black==25.9.0",
     "rich==14.2.0",
     "prettytable==3.16.0",
-    "rich-argparse==1.7.1",
+    "rich-argparse==1.7.2",
     "pre-commit==4.3.0",
 ]
 


### PR DESCRIPTION
Consolidates all open dependabot PRs into a single PR targeting `dev/1.1.x` (the new default branch).

## Dependencies updated

| Package | From | To |
|---------|------|----|
| `black` | 24.4.2 | 25.9.0 |
| `rich` | 13.9.4 | 14.2.0 |
| `prettytable` | 3.12.0 | 3.16.0 |
| `pre-commit` | 3.8.0 | 4.3.0 |
| `rich-argparse` | 1.6.0 | 1.7.2 |

> **Note:** `black`, `rich`, `prettytable`, and `pre-commit` were already bumped in `dev/1.1.x`. This PR adds the remaining `rich-argparse` bump and serves as the single merge point to close all dependabot PRs.

Closes #69, #70, #71, #72, #73