### PR TITLE
Start act shell workdir as APP_ROOT #95

### DIFF
--- a/arches_containers/manage.py
+++ b/arches_containers/manage.py
@@ -207,6 +207,19 @@ def _check_container_running(container_name):
     return result.stdout.strip() == "true"
 
 
+def _get_app_root(container_name):
+    '''
+    Returns the APP_ROOT environment variable from a running container, or None if not set.
+    '''
+    result = subprocess.run(
+        ["docker", "exec", container_name, "printenv", "APP_ROOT"],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    if result.returncode == 0:
+        return result.stdout.strip() or None
+    return None
+
+
 def shell_container(project_name, container=None, exec_cmd=None):
     '''
     Open an interactive shell or run a command in a project container.
@@ -219,12 +232,17 @@ def shell_container(project_name, container=None, exec_cmd=None):
     if not running:
         AcOutputManager.fail(f"Container '{container_name}' is not running. Start it with 'act up'.")
         return 1
+    workdir_flags = []
+    if container is None:
+        app_root = _get_app_root(container_name)
+        if app_root:
+            workdir_flags = ["-w", app_root]
     if exec_cmd:
-        command = ["docker", "exec", container_name, "sh", "-c", exec_cmd]
+        command = ["docker", "exec"] + workdir_flags + [container_name, "sh", "-c", exec_cmd]
     else:
         AcOutputManager.write(f"... Opening shell in container '{container_name}'.")
         AcOutputManager.write("... ℹ️ Type 'exit' or press Ctrl+D to return to the terminal.")
-        command = ["docker", "exec", "-it", container_name, "/bin/bash"]
+        command = ["docker", "exec", "-it"] + workdir_flags + [container_name, "/bin/bash"]
     AcOutputManager.stop_spinner()
     result = subprocess.run(command)
     return result.returncode

--- a/tests/test_shell_logs.py
+++ b/tests/test_shell_logs.py
@@ -20,11 +20,14 @@ def mock_workspace(mock_project):
         yield mock_ws_cls
 
 
-def _make_subprocess_side_effect(inspect_running: bool | None, exec_returncode: int = 0):
+APP_ROOT_VALUE = "/web/my-project"
+
+def _make_subprocess_side_effect(inspect_running: bool | None, exec_returncode: int = 0, app_root: str | None = APP_ROOT_VALUE):
     """
     Returns a side_effect function for subprocess.run that:
     - Responds to 'docker inspect' calls based on inspect_running
       (None → returncode=1 meaning not found, True/False → returncode=0 with stdout 'true'/'false')
+    - Responds to 'printenv APP_ROOT' calls with app_root (None → returncode=1)
     - Returns returncode=exec_returncode for all other docker commands
     """
     def side_effect(command, **kwargs):
@@ -36,6 +39,13 @@ def _make_subprocess_side_effect(inspect_running: bool | None, exec_returncode: 
             else:
                 result.returncode = 0
                 result.stdout = "true\n" if inspect_running else "false\n"
+        elif "printenv" in command and "APP_ROOT" in command:
+            if app_root:
+                result.returncode = 0
+                result.stdout = app_root + "\n"
+            else:
+                result.returncode = 1
+                result.stdout = ""
         else:
             result.returncode = exec_returncode
         return result
@@ -56,7 +66,7 @@ class TestShellContainer:
     def test_default_container_opens_interactive_bash(self, mock_subprocess_running, mock_workspace):
         shell_container("my_project")
         mock_subprocess_running.assert_called_with(
-            ["docker", "exec", "-it", "my-project-a1b2c", "/bin/bash"]
+            ["docker", "exec", "-it", "-w", APP_ROOT_VALUE, "my-project-a1b2c", "/bin/bash"]
         )
 
     def test_explicit_container_name_is_used(self, mock_subprocess_running, mock_workspace):
@@ -68,7 +78,7 @@ class TestShellContainer:
     def test_exec_cmd_produces_non_interactive_call(self, mock_subprocess_running, mock_workspace):
         shell_container("my_project", exec_cmd="python manage.py show_graphs")
         mock_subprocess_running.assert_called_with(
-            ["docker", "exec", "my-project-a1b2c", "sh", "-c", "python manage.py show_graphs"]
+            ["docker", "exec", "-w", APP_ROOT_VALUE, "my-project-a1b2c", "sh", "-c", "python manage.py show_graphs"]
         )
 
     def test_exec_cmd_with_explicit_container(self, mock_subprocess_running, mock_workspace):
@@ -83,11 +93,19 @@ class TestShellContainer:
             result = shell_container("my_project")
         assert result == 1
 
+    def test_default_container_no_app_root_falls_back_to_no_workdir(self, mock_workspace):
+        with patch("arches_containers.manage.subprocess.run") as mock_run:
+            mock_run.side_effect = _make_subprocess_side_effect(inspect_running=True, app_root=None)
+            shell_container("my_project")
+        mock_run.assert_called_with(
+            ["docker", "exec", "-it", "my-project-a1b2c", "/bin/bash"]
+        )
+
     def test_default_container_without_hash(self, mock_subprocess_running, mock_workspace, mock_project):
         mock_project.get_project_hash.return_value = ""
         result = shell_container("my_project")
         mock_subprocess_running.assert_called_with(
-            ["docker", "exec", "-it", "my-project", "/bin/bash"]
+            ["docker", "exec", "-it", "-w", APP_ROOT_VALUE, "my-project", "/bin/bash"]
         )
         assert result == 0
 


### PR DESCRIPTION
closes #95 

This pull request improves the behavior of the `shell_container` function in `arches_containers/manage.py` by ensuring that commands are executed in the correct working directory inside Docker containers, when possible. It does this by detecting the `APP_ROOT` environment variable from the running container and using it as the working directory for shell and command executions. The changes are thoroughly tested to ensure correct behavior in both cases where `APP_ROOT` is set and not set.

**Enhancements to container shell command execution:**

* Added a new helper function `_get_app_root` that retrieves the `APP_ROOT` environment variable from a running container, returning `None` if not set.
* Updated `shell_container` to use the `-w` Docker flag with the value of `APP_ROOT` (if available) as the working directory for both interactive shells and command execution. If `APP_ROOT` is not set, the flag is omitted.

**Improvements to testing:**

* Enhanced the subprocess mocking in tests to simulate the presence or absence of the `APP_ROOT` environment variable, enabling more accurate testing of the new logic. [[1]](diffhunk://#diff-bf69aa768a47926e39dcbcc48ddc005674490e28e8d35e47bbde81b9b4fa3e40L23-R30) [[2]](diffhunk://#diff-bf69aa768a47926e39dcbcc48ddc005674490e28e8d35e47bbde81b9b4fa3e40R42-R48)
* Updated existing tests and added a new test to verify that the correct Docker command is constructed when `APP_ROOT` is set and when it is not, ensuring that the fallback behavior is correct. [[1]](diffhunk://#diff-bf69aa768a47926e39dcbcc48ddc005674490e28e8d35e47bbde81b9b4fa3e40L59-R69) [[2]](diffhunk://#diff-bf69aa768a47926e39dcbcc48ddc005674490e28e8d35e47bbde81b9b4fa3e40L71-R81) [[3]](diffhunk://#diff-bf69aa768a47926e39dcbcc48ddc005674490e28e8d35e47bbde81b9b4fa3e40R96-R108)