### PR TITLE
Adds cli interactive ux

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,17 @@ act down [-p <project_name>] [-vb] [--app | --dep]
 
 #### Restart a Project
 
-Restarts the project containers by stopping and then starting them. Useful for applying changes such as new dependencies or forcing a rebuild.
+Restarts the project containers by stopping and then starting them. Useful for applying changes such as new dependencies or forcing a rebuild. Always operates on the active project.
 
 ```sh
 cd /path/to/workspace
-act restart [-p <project_name>] [-b] [-vb] [--app | --dep]
+act restart [-b] [-vb] [--app | --dep]
 ```
 
-- `-p`, `--project_name`: The name of the project. If excluded, the active project will be used.
 - `-b`, `--build`: Rebuild containers when composing up (after stopping them).
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
-- `--app`: Only operate on application containers (docker-compose.yml). Mutually exclusive with --dep.
-- `--dep`: Only operate on dependency containers (docker-compose-dependencies.yml). Mutually exclusive with --app.
+- `--app`: Only operate on application containers (docker-compose.yml). Mutually exclusive with `--dep`.
+- `--dep`: Only operate on dependency containers (docker-compose-dependencies.yml). Mutually exclusive with `--app`.
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ act [OPTIONS] COMMAND [ARGS]...
 
     This creates the arches-container project configuration and sets it as the active project.
 
+    Run without arguments to use the interactive prompts:
+
+    ```sh
+    act create
+    ```
+
+    Or pass arguments directly:
+
     ```sh
     act create -p my_project -v 8.1 --activate
     ```
@@ -78,13 +86,22 @@ act [OPTIONS] COMMAND [ARGS]...
 
 Steps to create a new container project.
 
+Run without arguments to use the interactive prompts — you will be asked to type a project name and then select an Arches version from the available templates:
+
+```sh
+cd /path/to/workspace
+act create
+```
+
+Or pass all arguments directly:
+
 ```sh
 cd /path/to/workspace
 act create -p <project_name> -v <version> [-r <repo_name>] [-o <organization>] [--activate]
 ```
 
-- `-p`, `--project_name`: The name of the project. This value will be slugified to lowercase with underscore separators.
-- `-v`, `--version`, `--ver`: The Arches version the project will be using (major.minor format).
+- `-p`, `--project_name`: The name of the project. This value will be slugified to lowercase with underscore separators. If omitted, you will be prompted to enter one.
+- `-v`, `--version`, `--ver`: The Arches version the project will be using (major.minor format). If omitted, you will be presented with a list of available versions sourced from the bundled templates, sorted newest-first. Unsupported versions are labelled.
 - `-r`, `--repo_name`: The name of the local repository folder to create for the project. v7.6 and higher only.
 - `-o`, `--organization`: The GitHub organization of the Arches repo (default: archesproject).
 - `--activate`: Activate the project after creation. If it is the first project then it will be activated by default.
@@ -161,12 +178,21 @@ act restart --dep -b
 
 #### Activate a Project
 
+Run without `-p` to choose from an interactive list of available projects (the currently active project is labelled):
+
+```sh
+cd /path/to/workspace
+act activate
+```
+
+Or pass the project name directly:
+
 ```sh
 cd /path/to/workspace
 act activate -p <project_name> [-vb]
 ```
 
-- `-p`, `--project_name`: The name of the project to activate.
+- `-p`, `--project_name`: The name of the project to activate. If omitted, an interactive selector is shown.
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
 
 ### List Projects
@@ -180,14 +206,21 @@ act list
 
 ### Delete a Project
 
-Steps to delete an existing container project.
+Run without `-p` to choose from an interactive list of available projects (the currently active project is labelled). You will be asked to confirm before the project is deleted:
 
 ```sh
 cd /path/to/workspace
-act delete -p <project_name>
+act delete
 ```
 
-- `-p`, `--project_name`: The name of the project to delete.
+Or pass the project name directly:
+
+```sh
+cd /path/to/workspace
+act delete [-p <project_name>]
+```
+
+- `-p`, `--project_name`: The name of the project to delete. If omitted, an interactive selector is shown.
 
 ### Generate Debug Config
 
@@ -200,16 +233,25 @@ act generate-debug-config
 
 ### Export a Project
 
-The user can export an arches-container project to a repository folder. This is useful when the user wants to share the project with others or store it in a version control system. The export command will create a folder called `.ac` in the repository folder and copy the necessary files to it.
+The user can export an arches-container project to a repository folder. This is useful when the user wants to share the project with others or store it in a version control system. The export command will create a folder called `.ac_<project_name>` in the repository folder and copy the necessary files to it.
 
-The docker compose files in the exported arches-container project will need to be run manually as the command only access those in the `.arches-containers` folder.
+The docker compose files in the exported arches-container project will need to be run manually as the command only accesses those in the `.arches-containers` folder.
+
+Run without `-p` to choose from an interactive list of available projects:
+
+```sh
+cd /path/to/workspace
+act export
+```
+
+Or pass arguments directly:
 
 ```sh
 cd /path/to/workspace
 act export [-p <project_name>] [-r <repo_path>] [--keep-repo-hash] [--yes|--no]
 ```
 
-- `-p`, `--project_name`: The name of the project to export. Default is the active project.
+- `-p`, `--project_name`: The name of the project to export. If omitted, an interactive selector is shown.
 - `-r`, `--repo_path`: The path to the repository folder if different to the default.
 - `--keep-repo-hash`: Keep the hash from an existing `.ac_<project_name>` config in the target repository.
 - `--yes`: Answer yes to all export prompts (non-interactive mode).
@@ -221,11 +263,20 @@ If `--keep-repo-hash` is not passed and the target `.ac_<project_name>` already 
 
 The user can import an arches-container project from a repository folder. This is useful when the user wants to use a project that has been shared with them or stored in a version control system.
 
+Run without `-p` to discover importable projects automatically. The CLI scans the workspace for `.ac_*/config.json` files at any depth and presents a list to choose from. Where the same project name exists in multiple locations, the relative path is shown to disambiguate:
+
 ```sh
-act import -p <project_name> [-r <repo_path>] [--new-hash | --hash <abc12>] [--yes|--no]
+cd /path/to/workspace
+act import
 ```
 
-- `-p`, `--project_name`: The name of the project to import. It will look for a folder at the path  in the repository folder.
+Or pass arguments directly:
+
+```sh
+act import [-p <project_name>] [-r <repo_path>] [--new-hash | --hash <abc12>] [--yes|--no]
+```
+
+- `-p`, `--project_name`: The name of the project to import. If omitted, importable projects are discovered interactively.
 - `-r`, `--repo_path`: The path to the repository folder if different to the default.
 - `--new-hash`: Generate a new hash for the imported project.
 - `--hash`: Set an explicit 5-character lowercase hexadecimal hash for the imported project.

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -60,6 +60,26 @@ def _interactive_project_select(message, choices):
     return selection[0]
 
 
+def _prompt_for_text(prompt):
+    """Show a simple text-input prompt. Returns the entered string, or None if Esc/Ctrl-C."""
+    from prompt_toolkit import prompt as pt_prompt
+    from prompt_toolkit.keys import Keys
+    from prompt_toolkit.key_binding import KeyBindings
+    cancelled = [False]
+    kb = KeyBindings()
+
+    @kb.add("escape")
+    def _esc(event):
+        cancelled[0] = True
+        event.app.exit(exception=KeyboardInterrupt)
+
+    try:
+        value = pt_prompt(prompt, key_bindings=kb).strip()
+    except (KeyboardInterrupt, EOFError):
+        return None
+    return value if value else None
+
+
 def _warn_if_project_unsupported(project_name, ac_project):
     """Emit a one-line warning if the project uses an unsupported Arches version (< 7.6)."""
     project_version = ac_project._config.get(AcProjectAttributes.PROJECT_ARCHES_VERSION.value, "")
@@ -74,8 +94,8 @@ def main():
     
     # Sub-parser for the create command
     parser_create = subparsers.add_parser("create", help="Create a new container project", formatter_class=parser.formatter_class)
-    parser_create.add_argument("-p", "--project_name", required=True, help="The name of the project. This value will be slugified to lowercase with underscore separators")
-    parser_create.add_argument("-v", "--version", "--ver", required=True, help="The arches version the project will be using (major.minor format)")
+    parser_create.add_argument("-p", "--project_name", required=False, default=None, help="The name of the project. This value will be slugified to lowercase with underscore separators")
+    parser_create.add_argument("-v", "--version", "--ver", required=False, default=None, help="The arches version the project will be using (major.minor format)")
     parser_create.add_argument("-r", "--repo_name", help="The name of the local repository folder to create for the project. v7.6 and higher only.")
     parser_create.add_argument("-o", "--organization", default="archesproject", help="The GitHub organization of the arches repo (default: archesproject)")
     parser_create.add_argument("-br", "--branch", help="The branch of the arches repo to use. Default is the 'dev/<version>.x' branch.")
@@ -173,6 +193,22 @@ def main():
 
     # ========================================================================================================
     if args.command == "create":
+        if args.project_name is None:
+            AcOutputManager.write("▶️  Create Project")
+            AcOutputManager.write("  Enter a project name (e.g. 'My Arches Project'). This will be slugified to lowercase with underscores (e.g. 'my_arches_project').")
+            entered = _prompt_for_text("  Project name: ")
+            if entered is None:
+                AcOutputManager.write("Creation cancelled.")
+                exit(0)
+            args.project_name = entered
+        if args.version is None:
+            version_items = ac_workspace.list_available_versions()
+            AcOutputManager.write("  Select an Arches version for your project:")
+            selected_version = _interactive_project_select("", [v["display_name"] for v in version_items])
+            if selected_version is None:
+                AcOutputManager.write("Creation cancelled.")
+                exit(0)
+            args.version = next(v["version"] for v in version_items if v["display_name"] == selected_version)
         with AcOutputManager("Creating project") as spinner:
             AcOutputManager.write(f"▶️  Creating project: {args.project_name}")
             

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -11,6 +11,55 @@ from arches_containers.utils.create_launch_config import generate_launch_config
 from arches_containers.utils.logger import AcOutputManager
 
 
+def _interactive_project_select(message, choices):
+    """Arrow-key selector. Returns the chosen string, or None if Esc/Ctrl-C is pressed."""
+    from prompt_toolkit import Application
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+
+    current = [0]
+    selection = [None]
+    kb = KeyBindings()
+
+    @kb.add("up")
+    def _up(event):
+        current[0] = (current[0] - 1) % len(choices)
+
+    @kb.add("down")
+    def _down(event):
+        current[0] = (current[0] + 1) % len(choices)
+
+    @kb.add("enter")
+    def _enter(event):
+        selection[0] = choices[current[0]]
+        event.app.exit()
+
+    @kb.add("escape")
+    @kb.add("c-c")
+    def _cancel(event):
+        event.app.exit()
+
+    def render():
+        lines = []
+        lines.append(("", "  (up/down arrow keys  Enter to confirm  Esc to cancel)\n\n"))
+        for i, choice in enumerate(choices):
+            if i == current[0]:
+                lines.append(("fg:ansigreen bold", f"  > {choice}\n"))
+            else:
+                lines.append(("", f"    {choice}\n"))
+        return lines
+
+    Application(
+        layout=Layout(Window(FormattedTextControl(render, focusable=False))),
+        key_bindings=kb,
+        full_screen=False,
+        refresh_interval=0.05,
+    ).run()
+    return selection[0]
+
+
 def _warn_if_project_unsupported(project_name, ac_project):
     """Emit a one-line warning if the project uses an unsupported Arches version (< 7.6)."""
     project_version = ac_project._config.get(AcProjectAttributes.PROJECT_ARCHES_VERSION.value, "")
@@ -61,7 +110,7 @@ def main():
 
     # Sub-parser for activating project
     parser_activate = subparsers.add_parser("activate", help="Set a project as the active project", formatter_class=parser.formatter_class)
-    parser_activate.add_argument("-p", "--project_name", required=True, help="The name of the project to activate")
+    parser_activate.add_argument("-p", "--project_name", required=False, default=None, help="The name of the project to activate. If omitted, an interactive selector is shown.")
     parser_activate.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
 
     # Sub-parser for the list command
@@ -69,7 +118,7 @@ def main():
     
     # Sub-parser for the delete command
     parser_delete = subparsers.add_parser("delete", help="Delete an existing container project", formatter_class=parser.formatter_class)
-    parser_delete.add_argument("-p", "--project_name", required=True, help="The name of the project to delete")
+    parser_delete.add_argument("-p", "--project_name", required=False, default=None, help="The name of the project to delete. If omitted, an interactive selector is shown.")
     
     # Sub-parser for the generate-launch-config command
     parser_launch = subparsers.add_parser("generate-debug-config", help="Generate vscode launch.json configuration for the workspace", formatter_class=parser.formatter_class)
@@ -85,7 +134,7 @@ def main():
 
     # Sub-parser for the import command
     parser_import = subparsers.add_parser("import", help="Import a project from a given repository folder", formatter_class=parser.formatter_class)
-    parser_import.add_argument("-p", "--project_name", required=True, help="The name of the project to import.")
+    parser_import.add_argument("-p", "--project_name", required=False, default=None, help="The name of the project to import. If omitted, importable projects are discovered interactively.")
     parser_import.add_argument("-r", "--repo_path", help="The path to the repository folder if different to the default.")
     import_hash_group = parser_import.add_mutually_exclusive_group()
     import_hash_group.add_argument("--new-hash", action="store_true", default=None, help="Generate a new hash after import.")
@@ -139,7 +188,30 @@ def main():
             try:
                 args.project_name = ac_settings.get_active_project().project_name
             except Exception as e:
-                AcOutputManager.fail("No project name passed and no active project set. Run 'arches-containers create' to create a new project.")
+                AcOutputManager.fail("🔴 No project name passed and no active project set. Run 'arches-containers create' to create a new project.")
+
+        if args.command == "activate" and args.project_name is None:
+            projects = ac_workspace.list_projects()
+            if not projects:
+                AcOutputManager.fail("🔴 No projects found. Run 'act create' to create a new project.")
+                exit(1)
+            try:
+                active_project_name = ac_settings.get_active_project().project_name
+            except Exception:
+                active_project_name = None
+            choices = [
+                f"{p} (active)" if p == active_project_name else p
+                for p in projects
+            ]
+            AcOutputManager.write("▶️ Activate Project...")
+            selected = _interactive_project_select(
+                "",
+                choices,
+            )
+            if selected is None:
+                AcOutputManager.write("Selection cancelled.")
+                exit(0)
+            args.project_name = selected.removesuffix(" (active)")
 
         with AcOutputManager(f"Running {args.command} command for project: {args.project_name}") as spinner:
             AcOutputManager.write(f"▶️  {args.command.capitalize()} command for project: {args.project_name}")
@@ -198,6 +270,29 @@ def main():
 
     # ========================================================================================================
     elif args.command == "delete":
+        if args.project_name is None:
+            projects = ac_workspace.list_projects()
+            if not projects:
+                AcOutputManager.fail("🔴 No projects found. Run 'act create' to create a new project.")
+                exit(1)
+            try:
+                active_project_name = ac_settings.get_active_project().project_name
+            except Exception:
+                active_project_name = None
+            choices = [
+                f"{p} (active)" if p == active_project_name else p
+                for p in projects
+            ]
+            AcOutputManager.write("▶️ Delete Project...")
+            selected = _interactive_project_select("", choices)
+            if selected is None:
+                AcOutputManager.write("Selection cancelled.")
+                exit(0)
+            args.project_name = selected.removesuffix(" (active)")
+        confirm = input(f"  Are you sure you want to delete '{args.project_name}'? [y/N] ").strip().lower()
+        if confirm != "y":
+            AcOutputManager.write("Deletion cancelled.")
+            exit(0)
         AcOutputManager.write(f"▶️  Deleting project: {args.project_name}")
         with AcOutputManager(f"Deleting project: {args.project_name}") as spinner:
             ac_workspace.delete_project(args.project_name)
@@ -210,15 +305,27 @@ def main():
     # ========================================================================================================
     elif args.command == "export":
         AcOutputManager.write("▶️  Exporting project")
-        if args.project_name == "" or args.project_name is None:
+        if args.project_name is None or args.project_name == "":
+            projects = ac_workspace.list_projects()
+            if not projects:
+                AcOutputManager.fail("🔴 No projects found. Run 'act create' to create a new project.")
+                exit(1)
             try:
-                args.project_name = ac_settings.get_active_project_name()
-                
-            except Exception as e:
-                AcOutputManager.fail("No project name passed and no active project set. Run 'arches-containers create' to create a new project.")
+                active_project_name = ac_settings.get_active_project().project_name
+            except Exception:
+                active_project_name = None
+            choices = [
+                f"{p} (active)" if p == active_project_name else p
+                for p in projects
+            ]
+            selected = _interactive_project_select("Select a project to export:", choices)
+            if selected is None:
+                AcOutputManager.write("Selection cancelled.")
+                exit(0)
+            args.project_name = selected.removesuffix(" (active)")
         export_project = ac_workspace.get_project(args.project_name)
         _warn_if_project_unsupported(args.project_name, export_project)
-        repo_path = args.repo_path if args.repo_path else os.path.join(ac_workspace.path, args.project_name)
+        repo_path = args.repo_path if args.repo_path else ac_workspace._get_project_repo_path(args.project_name)
         prompt_default = True if args.yes else False if args.no else None
         ac_workspace.export_project(
             args.project_name,
@@ -229,12 +336,27 @@ def main():
     
     # ========================================================================================================
     elif args.command == "import":
-        AcOutputManager.write("▶️  Importing project")
-        if args.project_name == "" or args.project_name is None:
-            AcOutputManager.fail("Project name is required for import.")
-
-        repo_path = args.repo_path if args.repo_path else os.path.join(ac_workspace.path, args.project_name)
+        AcOutputManager.write("▶️  Import project")
+        if args.project_name is None or args.project_name == "":
+            with AcOutputManager(f"... Discovering importable projects") as spinner:
+                AcOutputManager.text("... Discovering importable projects")
+                discovered = ac_workspace.discover_importable_projects()
+            if not discovered:
+                AcOutputManager.fail("🔴 No importable projects found. Ensure the repository folder contains a .ac_<project_name>/config.json file.")
+                exit(1)
+            choices = [d["display_name"] for d in discovered]
+            selected = _interactive_project_select("Select a project to import:", choices)
+            if selected is None:
+                AcOutputManager.write("Selection cancelled.")
+                exit(0)
+            match = next(d for d in discovered if d["display_name"] == selected)
+            args.project_name = match["project_name"]
+            import_repo_path = match["repo_path"]
+        else:
+            import_repo_path = args.repo_path if args.repo_path else os.path.join(ac_workspace.path, args.project_name)
+        repo_path = args.repo_path if args.repo_path else import_repo_path
         prompt_default = True if args.yes else False if args.no else None
+        AcOutputManager.write("... Importing project")
         ac_workspace.import_project(
             args.project_name,
             repo_path,

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -121,7 +121,6 @@ def main():
 
     # Sub-parser for restarting containers
     parser_restart = subparsers.add_parser("restart", help="Restart the project containers (down + up)", formatter_class=parser.formatter_class)
-    parser_restart.add_argument("-p", "--project_name", default="", help="The name of the project. If excluded, the active project will be used.")
     parser_restart.add_argument("-b", "--build", action="store_true", help="Rebuild containers when composing up")
     parser_restart.add_argument("-vb", "--verbose", action="store_true", help="Print verbose output during the compose processes")
     container_group_restart = parser_restart.add_mutually_exclusive_group()
@@ -220,7 +219,12 @@ def main():
                 AcOutputManager.warn(f"Arches version {args.version} is no longer actively maintained, so this template may not work as expected and need manual adjustments to fix.")
     # ========================================================================================================
     elif args.command in ["up", "down", "activate", "restart"]:
-        if args.project_name == "" and args.command != "activate":
+        if args.command == "restart":
+            try:
+                args.project_name = ac_settings.get_active_project().project_name
+            except Exception:
+                AcOutputManager.fail("🔴 No active project set. Run 'act activate' to set an active project.")
+        elif args.project_name == "" and args.command != "activate":
             try:
                 args.project_name = ac_settings.get_active_project().project_name
             except Exception as e:

--- a/arches_containers/utils/workspace.py
+++ b/arches_containers/utils/workspace.py
@@ -358,11 +358,12 @@ class AcWorkspace:
 
             project[AcProjectAttributes.PROJECT_REPO_DIRECTORY.value] = project_repo_directory
             project.save()
+        return project_repo_directory
 
     def _get_project_repo_path(self, project_name):
-        return os.path.join(self._path(), self._get_project_repo_name(project_name))
+        return os.path.join(self._path, self._get_project_repo_name(project_name))
 
-    def _read_project_hash_from_config(self, project_path):
+    def _read_project_hash_from_config(self, project_path) -> str:
         config_path = os.path.join(project_path, "config.json")
         if not os.path.exists(config_path):
             return ""
@@ -487,6 +488,60 @@ class AcWorkspace:
         context = self._get_ac_directory_path()
         return [name for name in os.listdir(context) if os.path.isdir(os.path.join(context, name))]
 
+    def discover_importable_projects(self):
+        '''
+        Recursively scans the workspace path for directories containing a
+        .ac_*/config.json export file. Skips the .arches_containers management
+        directory itself.
+
+        Returns a list of dicts:
+            {"project_name": str, "repo_path": str, "display_name": str}
+        where repo_path is the directory containing the .ac_<project_name> folder
+        and display_name is "project_name" for unique entries, or
+        "project_name  (relative/path)" when the same project_name appears
+        in multiple locations.
+        '''
+        search_root = self._path
+        ac_dir = self._get_ac_directory_path()
+        found = []
+
+        for dirpath, dirnames, _ in os.walk(search_root):
+            # Skip the .arches_containers management directory
+            dirnames[:] = [
+                d for d in dirnames
+                if os.path.join(dirpath, d) != ac_dir
+                and not d.startswith(".ac_")
+            ]
+            for entry in os.scandir(dirpath):
+                if not entry.is_dir() or not entry.name.startswith(".ac_"):
+                    continue
+                config_path = os.path.join(entry.path, "config.json")
+                if not os.path.isfile(config_path):
+                    continue
+                try:
+                    with open(config_path, "r", encoding="utf-8") as f:
+                        config = json.load(f)
+                    project_name = config.get("project_name", "")
+                    if project_name:
+                        rel = os.path.relpath(dirpath, search_root)
+                        found.append({"project_name": project_name, "repo_path": dirpath, "_rel": rel})
+                except (OSError, ValueError):
+                    pass
+
+        # Compute display_name: add relative path for duplicates
+        from collections import Counter
+        name_counts = Counter(d["project_name"] for d in found)
+        for d in found:
+            if name_counts[d["project_name"]] > 1:
+                d["display_name"] = f"{d['project_name']}  (./{d['_rel']})"
+            else:
+                d["display_name"] = d["project_name"]
+            del d["_rel"]
+
+        found.sort(key=lambda d: d["display_name"].lower())
+        return found
+
+
     def get_settings(self):
         '''
         Returns the AcSettings object.
@@ -503,16 +558,25 @@ class AcWorkspace:
         if project is None:
             raise Exception(f"Project {project_name} not found.")
         
+        # check that the target repo path exists and is a directory
+        if not os.path.exists(repo_path) or not os.path.isdir(repo_path):
+            AcOutputManager.fail(f"Export failed. The target repo path '{repo_path}' does not exist or is not a directory.")
+            exit(1)
+
         project_path = project.get_project_path()
         ac_repo_path = os.path.join(repo_path, EXPORT_AC_FOLDER)
+        repo_dir_name = os.path.basename(repo_path)
         
         existing_repo_hash = ""
         use_repo_hash = False
 
         if os.path.exists(ac_repo_path):
             existing_repo_hash = self._read_project_hash_from_config(ac_repo_path)
-            if project.supports_project_hash() and existing_repo_hash:
-                if keep_repo_hash is None:
+            project_hash = project.get_project_hash()
+            if project_hash and existing_repo_hash:
+                if project_hash == existing_repo_hash:
+                    use_repo_hash = True
+                elif keep_repo_hash is None:
                     use_repo_hash = self._confirm(
                         "The export target already has a hash. Keep the repo hash so teammates can import without creating new Docker objects? (y/n): ",
                         prompt_default,
@@ -552,7 +616,7 @@ class AcWorkspace:
                     file_path = os.path.join(root, file)
                     with open(file_path, "r+") as f:
                         content = f.read()
-                        content = content.replace(f"/.arches_containers/{project_name}", f"/{project_name}/{EXPORT_AC_FOLDER}")
+                        content = content.replace(f"/.arches_containers/{project_name}", f"/{repo_dir_name}/{EXPORT_AC_FOLDER}")
                         f.seek(0)
                         f.write(content)
                         f.truncate()

--- a/arches_containers/utils/workspace.py
+++ b/arches_containers/utils/workspace.py
@@ -296,6 +296,7 @@ class AcWorkspace:
                     return os.path.join(dirpath, dirname)
         return None
 
+
     def _get_urlsafe_project_name(self, project_name):
         return slugify(text=project_name, separator="-")
 
@@ -422,6 +423,26 @@ class AcWorkspace:
 
 
     # PUBLIC METHODS
+    
+    def list_available_versions(self):
+        '''
+        Returns a list of dicts sorted newest-first:
+            {"version": str, "display_name": str}
+        where display_name appends " (unsupported)" for versions < 7.6.
+        '''
+        versions = []
+        for entry in os.scandir(TEMPLATE_PATH):
+            if entry.is_dir() and entry.name.startswith("_") and entry.name.endswith("_"):
+                versions.append(entry.name.strip("_"))
+        versions.sort(key=lambda v: [int(x) for x in v.split(".")], reverse=True)
+        return [
+            {
+                "version": v,
+                "display_name": v if _is_version_supported(v) else f"{v} (unsupported)",
+            }
+            for v in versions
+        ]
+    
     def get_project(self, project_name) -> AcProject:
         try:
             return AcProject(project_name, self._get_ac_directory_path())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "black==25.9.0",
     "rich==14.2.0",
     "prettytable==3.16.0",
+    "prompt_toolkit>=3.0.0",
     "rich-argparse==1.7.2",
     "pre-commit==4.3.0",
 ]

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -9,6 +9,7 @@
 ### Notable Changes
 
 - Adds support for Arches 8.1 [#92](https://github.com/HistoricEngland/arches-containers/pull/92).
+- Adds interactive CLI support for `create`, `activate`, `delete`, `export`, and `import` commands [#98](https://github.com/HistoricEngland/arches-containers/pull/98).
 - Removes the `init` command — initialisation is now performed automatically by `up` when a project has not yet been initialised [#87](https://github.com/HistoricEngland/arches-containers/pull/87).
 - Adds a `shell` command to open an interactive shell inside a project container, with a `--exec` option for running non-interactive commands from scripts [#90](https://github.com/HistoricEngland/arches-containers/pull/90).
 - Adds a `logs` command to view container logs, with a `--follow`/`-f` option to stream output in real time [#90](https://github.com/HistoricEngland/arches-containers/pull/90).


### PR DESCRIPTION
closes #97 

This pull request significantly enhances the user experience of the `arches-containers` CLI by introducing interactive prompts for project-related commands, making the workflow more intuitive and reducing the need for manual argument specification. The documentation in `README.md` is updated accordingly to reflect these improvements. The most important changes are grouped below:

**Interactive CLI Improvements:**

* Added interactive arrow-key selector and text input prompts using `prompt_toolkit` for commands such as `create`, `activate`, `delete`, `export`, and `import`, allowing users to select or enter project names and versions interactively when arguments are omitted. [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR14-R82) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR195-R210) [[3]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL138-R254) [[4]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR313-R335) [[5]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL213-R368)
* Updated command argument parsing so that `--project_name` and `--version` are now optional for relevant commands. If omitted, the CLI prompts the user interactively. [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL28-R98) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL55) [[3]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL64-R140) [[4]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL88-R156)

**Command Behavior Changes:**

* The `restart` command now always operates on the active project; the `-p/--project_name` argument is removed for this command. [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL55) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R150)
* For `activate`, `delete`, `export`, and `import`, omitting the project name triggers an interactive selector, with active projects labeled accordingly. [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL138-R254) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR313-R335) [[3]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL213-R368)

**Documentation Updates:**

* Revised `README.md` to document the new interactive behavior for `create`, `activate`, `delete`, `export`, and `import` commands, including updated usage examples and clearer explanations of argument behavior. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R70) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R89-R104) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R150) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R180-R194) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L183-R222) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L203-R253) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R265-R278)

**Minor Usability Enhancements:**

* Improved user feedback and cancellation handling throughout interactive flows (e.g., clear cancellation messages, confirmation prompts for deletion). [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR195-R210) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL138-R254) [[3]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR313-R335) [[4]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL213-R368)

These changes make the CLI more user-friendly, especially for new users or those managing multiple projects.