### PR TITLE
Add checks for active project with running containers in CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ act down [-p <project_name>] [-vb] [--app | --dep]
 
 Restarts the project containers by stopping and then starting them. Useful for applying changes such as new dependencies or forcing a rebuild. Always operates on the active project.
 
+> ℹ️ The restart command will fail if the active project's containers are not currently running. Use `act up` to start the project first.
+
 ```sh
 cd /path/to/workspace
 act restart [-b] [-vb] [--app | --dep]
@@ -193,6 +195,8 @@ act activate -p <project_name> [-vb]
 
 - `-p`, `--project_name`: The name of the project to activate. If omitted, an interactive selector is shown.
 - `-vb`, `--verbose`: Print verbose output during the compose processes.
+
+> ℹ️ Activating a different project will fail if the current active project's containers are running. Use `act down` to stop them first.
 
 ### List Projects
 

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -224,6 +224,8 @@ def main():
                 args.project_name = ac_settings.get_active_project().project_name
             except Exception:
                 AcOutputManager.fail("🔴 No active project set. Run 'act activate' to set an active project.")
+            if not ac_workspace.is_active_project_running():
+                AcOutputManager.fail("🔴 No containers are currently running. Run 'act up' to start the project first.")
         elif args.project_name == "" and args.command != "activate":
             try:
                 args.project_name = ac_settings.get_active_project().project_name
@@ -270,6 +272,12 @@ def main():
                 AcOutputManager.pretty_write_args(vars(args))
 
             if args.command == "activate":
+                current_active = ac_settings.get_active_project_name()
+                if current_active and current_active != args.project_name and ac_workspace.is_active_project_running():
+                    AcOutputManager.fail(
+                        f"🔴 Project '{current_active}' is currently up. "
+                        f"Run 'act down' to stop it before activating another project."
+                    )
                 ac_settings.set_active_project(args.project_name)
                 arches_repo_helper.clone_and_checkout_repo(args.project_name, verbose=args.verbose)
                 AcOutputManager.complete_step(f"Project '{args.project_name}' set as active.")

--- a/arches_containers/utils/workspace.py
+++ b/arches_containers/utils/workspace.py
@@ -569,6 +569,24 @@ class AcWorkspace:
         '''
         return AcSettings(self)
 
+    def is_active_project_running(self) -> bool:
+        '''
+        Returns True if the active project has any running containers.
+        '''
+        try:
+            settings = self.get_settings()
+            if settings.settings["active_project"] == "":
+                return False
+            active_project = settings.get_active_project()
+            if active_project is None:
+                return False
+            return has_running_project_containers(
+                active_project.project_name,
+                active_project[AcProjectAttributes.PROJECT_NAME_URLSAFE.value],
+            )
+        except Exception:
+            return False
+
     def export_project(self, project_name, repo_path, keep_repo_hash=None, prompt_default=None):
         '''
         Exports a project from the .arches-containers folder to the root of a given repo folder.

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -24,6 +24,7 @@
 - Adds support for "kebab-case" repository names [#75](https://github.com/HistoricEngland/arches-containers/pull/75).
 - Adds DeepWiki link to the README [#75](https://github.com/HistoricEngland/arches-containers/pull/75).
 - Changes CLI banner to be more compact [#75](https://github.com/HistoricEngland/arches-containers/pull/75).
+- Prevents activating a different project or running `restart` when the active project's containers are already up or not running respectively [#102](https://github.com/HistoricEngland/arches-containers/pull/102).
 
 ## Installation Instructions
 

--- a/tests/test_activate.py
+++ b/tests/test_activate.py
@@ -1,0 +1,64 @@
+import sys
+from unittest.mock import patch, call
+from arches_containers.main import main
+
+
+def run_cli(args):
+    sys.argv = ["arches-containers"] + args
+    try:
+        main()
+    except SystemExit:
+        pass
+
+
+def test_activate_blocked_when_different_project_running():
+    """Issue #99: activating a different project should fail when containers are running."""
+    with patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo"), \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager") as mock_output:
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "project_a"
+        mock_settings.get_active_project_name.return_value = "project_a"
+        mock_workspace.return_value.is_active_project_running.return_value = True
+        mock_workspace.return_value.get_project.return_value._config = {}
+        mock_output.fail.side_effect = SystemExit(1)
+
+        run_cli(["activate", "-p", "project_b"])
+
+        mock_output.fail.assert_called_once()
+        assert "project_a" in mock_output.fail.call_args[0][0]
+        mock_settings.set_active_project.assert_not_called()
+
+
+def test_activate_allowed_when_activating_same_project():
+    """Issue #99: activating the already-active project should not be blocked even if containers are up."""
+    with patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo"), \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager") as mock_output:
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "project_a"
+        mock_settings.get_active_project_name.return_value = "project_a"
+        mock_workspace.return_value.is_active_project_running.return_value = True
+        mock_workspace.return_value.get_project.return_value._config = {}
+
+        run_cli(["activate", "-p", "project_a"])
+
+        mock_output.fail.assert_not_called()
+        mock_settings.set_active_project.assert_called_once_with("project_a")
+
+
+def test_activate_allowed_when_no_containers_running():
+    """Issue #99: activating a different project should succeed when no containers are running."""
+    with patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo"), \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager") as mock_output:
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "project_a"
+        mock_settings.get_active_project_name.return_value = "project_a"
+        mock_workspace.return_value.is_active_project_running.return_value = False
+        mock_workspace.return_value.get_project.return_value._config = {}
+
+        run_cli(["activate", "-p", "project_b"])
+
+        mock_output.fail.assert_not_called()
+        mock_settings.set_active_project.assert_called_once_with("project_b")

--- a/tests/test_restart.py
+++ b/tests/test_restart.py
@@ -20,7 +20,8 @@ def test_restart_runs_down_and_up():
         # Simulate active project
         mock_settings = mock_workspace.return_value.get_settings.return_value
         mock_settings.get_active_project.return_value.project_name = "demo"
-        run_cli(["restart", "-p", "demo"])
+        mock_workspace.return_value.is_active_project_running.return_value = True
+        run_cli(["restart"])
         # Should call down then up
         assert mock_compose.call_count == 2
         assert mock_compose.call_args_list[0][0][1] == "down"
@@ -33,7 +34,8 @@ def test_restart_with_build_and_verbose():
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
         mock_settings.get_active_project.return_value.project_name = "demo"
-        run_cli(["restart", "-p", "demo", "-b", "-vb"])
+        mock_workspace.return_value.is_active_project_running.return_value = True
+        run_cli(["restart", "-b", "-vb"])
         # Should call down (no build), then up (with build)
         assert mock_compose.call_count == 2
         assert mock_compose.call_args_list[0][0][2] is False  # build for down
@@ -46,7 +48,8 @@ def test_restart_with_app_flag():
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
         mock_settings.get_active_project.return_value.project_name = "demo"
-        run_cli(["restart", "-p", "demo", "--app"])
+        mock_workspace.return_value.is_active_project_running.return_value = True
+        run_cli(["restart", "--app"])
         # Should call down then up with app container type
         assert mock_compose.call_count == 2
         assert mock_compose.call_args_list[0][0][4] == "app"  # container_type for down
@@ -59,7 +62,8 @@ def test_restart_with_dep_flag():
          patch("arches_containers.main.AcOutputManager"):
         mock_settings = mock_workspace.return_value.get_settings.return_value
         mock_settings.get_active_project.return_value.project_name = "demo"
-        run_cli(["restart", "-p", "demo", "--dep"])
+        mock_workspace.return_value.is_active_project_running.return_value = True
+        run_cli(["restart", "--dep"])
         # Should call down then up with dep container type
         assert mock_compose.call_count == 2
         assert mock_compose.call_args_list[0][0][4] == "dep"  # container_type for down
@@ -120,6 +124,22 @@ def test_up_initialised_project_skips_init():
         mock_clone.assert_called_once()
         mock_init.assert_not_called()
         mock_compose.assert_called_once()
+
+
+def test_restart_blocked_when_no_containers_running():
+    """Issue #101: restart should fail if no containers are currently running."""
+    with patch("arches_containers.main.compose_project") as mock_compose, \
+         patch("arches_containers.main.arches_repo_helper.clone_and_checkout_repo"), \
+         patch("arches_containers.main.AcWorkspace") as mock_workspace, \
+         patch("arches_containers.main.AcOutputManager") as mock_output:
+        mock_settings = mock_workspace.return_value.get_settings.return_value
+        mock_settings.get_active_project.return_value.project_name = "demo"
+        mock_workspace.return_value.is_active_project_running.return_value = False
+        mock_output.fail.side_effect = SystemExit(1)
+        run_cli(["restart"])
+        mock_output.fail.assert_called_once()
+        assert "No containers are currently running" in mock_output.fail.call_args[0][0]
+        mock_compose.assert_not_called()
 
 
 def test_app_and_dep_flags_mutually_exclusive():

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -4,6 +4,7 @@ import shutil
 import json
 import platform
 from types import SimpleNamespace
+from unittest.mock import patch
 from arches_containers.utils.workspace import (
     AcWorkspace, 
     AcSettings, 
@@ -260,6 +261,27 @@ class TestAcWorkspace:
         ]
         # Export should be cancelled without prompting, so no timestamp backup should be created.
         assert backup_candidates == []
+
+class TestAcWorkspaceIsActiveProjectRunning:
+    def test_returns_true_when_containers_running(self, workspace_with_project):
+        workspace, project_name = workspace_with_project
+        workspace.get_settings().set_active_project(project_name)
+        with patch("arches_containers.utils.workspace.has_running_project_containers", return_value=True):
+            assert workspace.is_active_project_running() is True
+
+    def test_returns_false_when_no_containers_running(self, workspace_with_project):
+        workspace, project_name = workspace_with_project
+        workspace.get_settings().set_active_project(project_name)
+        with patch("arches_containers.utils.workspace.has_running_project_containers", return_value=False):
+            assert workspace.is_active_project_running() is False
+
+    def test_returns_false_when_no_active_project(self, temp_workspace):
+        temp_workspace.get_settings().clear_active_project()
+        with patch("arches_containers.utils.workspace.has_running_project_containers") as mock_check:
+            result = temp_workspace.is_active_project_running()
+        assert result is False
+        mock_check.assert_not_called()
+
 
 class TestAcSettings:
     def test_settings_creation(self, temp_workspace):


### PR DESCRIPTION
Closes #99 and #100

This pull request introduces improved safety checks and error handling for project activation and container management in the `arches_containers` CLI, addressing issues where users could inadvertently activate a new project or restart containers when none are running. It also adds comprehensive tests to ensure these behaviors are enforced.

**Core logic and safety improvements:**

* Added a check in `main.py` to prevent running commands (like `restart`) if no containers are currently running, displaying a clear error message to the user.
* When activating a project, the CLI now blocks activation of a different project if containers from another project are still running, instructing the user to stop them first.
* Introduced the `is_active_project_running` method in `AcWorkspace` to reliably determine if the active project has any running containers, used by the CLI for these new safety checks.

**Testing improvements:**

* Added new tests in `tests/test_activate.py` to verify that activating a different project is blocked if containers are running, and allowed otherwise.
* Added a test in `tests/test_restart.py` to ensure that attempting to restart when no containers are running fails as expected.
* Added a test class in `tests/test_workspace.py` to verify correct behavior of the new `is_active_project_running` method under various scenarios.

**Test refactoring:**

* Updated existing tests in `tests/test_restart.py` to remove unnecessary `-p` arguments and ensure the new safety checks are exercised. [[1]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL23-R24) [[2]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL36-R38) [[3]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL49-R52) [[4]](diffhunk://#diff-e034e1c1d986a9ad0c2b4ac49b4d031907cf42f3913bd0747477bc614cfac06cL62-R66)

These changes collectively make project and container management safer and more predictable for users, while ensuring robust test coverage for the new behaviors.