### PR TITLE
update version to 1.1.0rc2

### DIFF
--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.1.0rc1"
+AC_VERSION = "1.1.0rc2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.1.0rc1"
+version = "1.1.0rc2"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Supports Arches 6.1 to 8.0 (current development version)."
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }


### PR DESCRIPTION
Closes #100 

This pull request updates the version of the `arches-containers` package from `1.1.0rc1` to `1.1.0rc2` in both the code and project metadata.

Version bump:

* Updated `AC_VERSION` in `arches_containers/__init__.py` to `1.1.0rc2`.
* Updated the `version` field in `pyproject.toml` to `1.1.0rc2`.