### PR TITLE
Prepares 1.1.0 release

### DIFF
--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.1.0rc2"
+AC_VERSION = "1.1.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.1.0rc2"
-description = "A python developer tool for Arches Project that provides a way to create arches development environments. Supports Arches 6.1 to 8.0 (current development version)."
-requires-python = ">=3.9"
+version = "1.1.0"
+description = "A python developer tool for Arches Project that provides a way to create arches development environments. Provides templates for Arches v6.1 to v8.1 (v7.6 to v8.1 in active support)."
+requires-python = ">=3.11"
 license = { text = "AGPL-3.0" }
 keywords = ["arches", "development", "containers"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Programming Language :: Python :: 3",

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -60,7 +60,7 @@ There is no automatic migration for existing act project configurations, so this
 7. If you took a database backup, restore it into the new database volume created by the new configuration. You'll need to reindex elasticsearch after restoring the database, and can use the new `act shell` command to run the necessary management commands inside the project container. For example:
 
    ```bash
-   act shell --exec "cd <project_directory> && python manage.py es reindex_database -mp"
+   act shell --exec "python manage.py es reindex_database -mp"
    ```
 
 > ℹ️ If you have previously exported this act project into your repository, don't forget to export the updated configuration back into your repository to ensure the latest version is saved.

--- a/releases/1.1.0.md
+++ b/releases/1.1.0.md
@@ -6,6 +6,10 @@
 > If you are using an older version of Arches, you can continue to create act projects using the existing templates, but any issues that arise will need to be addressed by the developer.
 > Best efforts have been made to ensure backward compatibility for existing act projects, but it is recommended to update to the latest templates when possible to take advantage of new features and fixes.
 
+### Breaking Change
+
+- Python 3.8 support removed in a number of dependencies for the CLI. Unsuported templates that use 3.8 are still available but may no work without manual intervention.
+
 ### Notable Changes
 
 - Adds support for Arches 8.1 [#92](https://github.com/HistoricEngland/arches-containers/pull/92).


### PR DESCRIPTION
This pull request finalizes the release of version 1.1.0 of the `arches-containers` project, moving it from a release candidate to a stable production release. The update includes important changes to Python version support, project metadata, and documentation to reflect the new release and its compatibility updates.

**Release and compatibility updates:**

* Updated the project version from `1.1.0rc2` to `1.1.0` in both `arches_containers/__init__.py` and `pyproject.toml`, and promoted the development status to "Production/Stable". [[1]](diffhunk://#diff-43f48e97d0ff2e864b101939e296d742da6b548c9656fbe00d7a02c72349c065L1-R1) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R18)
* Increased the minimum required Python version to 3.11, and removed support for Python 3.8, as documented in the release notes. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R18) [[2]](diffhunk://#diff-b08b664e8aa3f924b131c1a4a7d276e5fc9dc908bb9276b5ff3bbc85f7964ffeR9-R12)
* Updated the project description to clarify supported Arches versions (v6.1 to v8.1, with active support for v7.6 to v8.1).
* Improved documentation in the release notes to highlight the breaking change regarding Python 3.8 support and clarified instructions for reindexing Elasticsearch after a database restore. [[1]](diffhunk://#diff-b08b664e8aa3f924b131c1a4a7d276e5fc9dc908bb9276b5ff3bbc85f7964ffeR9-R12) [[2]](diffhunk://#diff-b08b664e8aa3f924b131c1a4a7d276e5fc9dc908bb9276b5ff3bbc85f7964ffeL63-R67)