### PR TITLE
Update pull request trigger branch from 'release/**' to 'dev/**'

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Run Tests
 on:
   pull_request:
     branches:
-    - 'release/**'
+    - 'dev/**'
     - 'main'
 
 jobs:

--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.1.1"
+AC_VERSION = "1.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.1.1"
+version = "1.1.2"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Provides templates for Arches v6.1 to v8.1 (v7.6 to v8.1 in active support)."
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }

--- a/tests/test_shell_logs.py
+++ b/tests/test_shell_logs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from unittest.mock import patch, MagicMock, call
 from arches_containers.manage import shell_container, logs_container


### PR DESCRIPTION
This pull request updates the test workflow trigger to better align with the current branch strategy.

Workflow configuration:

* [`.github/workflows/run-tests.yml`](diffhunk://#diff-7314d0ebbd2e9537ae4889316745b4fd2fa43cb86275c9caae18a86ba228b642L6-R6): The workflow will now run on pull requests targeting `dev/**` branches instead of `release/**` branches.