### PR TITLE
update 1.2.x from 1.1.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Run Tests
 on:
   pull_request:
     branches:
-    - 'release/**'
+    - 'dev/**'
     - 'main'
 
 jobs:

--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.1.0"
+AC_VERSION = "1.1.1"

--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.1.1"
+AC_VERSION = "1.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "arches-containers"
 version = "1.1.0"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Provides templates for Arches v6.1 to v8.1 (v7.6 to v8.1 in active support)."
-requires-python = ">=3.11"
+requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }
 keywords = ["arches", "development", "containers"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.1.0"
+version = "1.1.1"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Provides templates for Arches v6.1 to v8.1 (v7.6 to v8.1 in active support)."
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.1.1"
+version = "1.1.2"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Provides templates for Arches v6.1 to v8.1 (v7.6 to v8.1 in active support)."
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }

--- a/tests/test_shell_logs.py
+++ b/tests/test_shell_logs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from unittest.mock import patch, MagicMock, call
 from arches_containers.manage import shell_container, logs_container


### PR DESCRIPTION
This pull request includes minor version updates, Python version compatibility improvements, and a change to the test workflow trigger branches. The most important changes are summarized below.

Version updates:

* Updated `version` in both `pyproject.toml` and `arches_containers/__init__.py` from `1.1.0` to `1.1.2` to reflect the new release. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7-R9) [[2]](diffhunk://#diff-43f48e97d0ff2e864b101939e296d742da6b548c9656fbe00d7a02c72349c065L1-R1)

Python compatibility:

* Lowered the minimum required Python version from 3.11 to 3.9 in `pyproject.toml` to support more environments.

CI/CD workflow:

* Changed the GitHub Actions test workflow to trigger on `dev/**` branches instead of `release/**` branches in `.github/workflows/run-tests.yml`.

Testing:

* Added `from __future__ import annotations` to `tests/test_shell_logs.py` for forward compatibility with type annotations.