### PR TITLE
Fix import/export path handling #114

### DIFF
--- a/arches_containers/utils/workspace.py
+++ b/arches_containers/utils/workspace.py
@@ -688,6 +688,7 @@ class AcWorkspace:
         
         shutil.copytree(ac_repo_path, project_path, dirs_exist_ok=True)
         
+        repo_dir_name = os.path.basename(repo_path)
         # Modify Docker YAML files
         for root, dirs, files in os.walk(project_path):
             for file in files:
@@ -695,7 +696,7 @@ class AcWorkspace:
                     file_path = os.path.join(root, file)
                     with open(file_path, "r+") as f:
                         content = f.read()
-                        content = content.replace(f"/{project_name}/{IMPORT_AC_FOLDER}", f"/.arches_containers/{project_name}")
+                        content = content.replace(f"/{repo_dir_name}/{IMPORT_AC_FOLDER}", f"/.arches_containers/{project_name}")
                         f.seek(0)
                         f.write(content)
                         f.truncate()

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -119,6 +119,25 @@ class TestAcWorkspace:
         if line is not None:
             assert line.strip().startswith("platform: linux/arm64")
 
+    def test_import_project_rewrites_paths_when_repo_dir_differs_from_project_name(self, workspace_with_project, tmp_path):
+        """Importing from a directory whose name differs from project_name (e.g. act-configs structure)
+        should correctly rewrite YAML paths to /.arches_containers/<project_name>."""
+        workspace, project_name = workspace_with_project
+        # Use a directory name that does NOT match project_name, simulating act-configs layout
+        repo_path = tmp_path / "arches-her"
+        repo_path.mkdir()
+
+        workspace.export_project(project_name, str(repo_path))
+        workspace.delete_project(project_name)
+        workspace.import_project(project_name, str(repo_path), new_hash=False)
+
+        compose_path = os.path.join(workspace._get_ac_directory_path(), project_name, "docker-compose.yml")
+        if os.path.exists(compose_path):
+            with open(compose_path) as f:
+                content = f.read()
+            assert f"/.arches_containers/{project_name}" in content
+            assert f"/arches-her/.ac_{project_name}" not in content
+
     def test_import_project_with_explicit_hash(self, workspace_with_project, tmp_path):
         workspace, project_name = workspace_with_project
         repo_path = tmp_path / "test_repo_explicit_hash"


### PR DESCRIPTION
Fixes #114 

This pull request updates the project import logic to correctly handle cases where the source repository directory name is different from the project name, ensuring that YAML path rewrites are accurate. It also adds a corresponding test to verify this behavior.

**Project import logic improvements:**

* Updated `import_project` in `workspace.py` to use the source repository directory name (`repo_dir_name`) instead of `project_name` when rewriting YAML paths, ensuring correct path replacements when the directory name and project name differ.

**Testing enhancements:**

* Added a test (`test_import_project_rewrites_paths_when_repo_dir_differs_from_project_name`) to verify that importing from a directory with a different name than the project correctly rewrites YAML paths, preventing incorrect references to the original directory.