### PR TITLE
Add remote catalog utilities and refactor config download

### DIFF
--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -9,6 +9,7 @@ import arches_containers.utils.arches_repo_helper as arches_repo_helper
 from arches_containers.utils.workspace import AcWorkspace, AcSettings, AcProject, AcProjectAttributes, _is_version_supported
 from arches_containers.utils.create_launch_config import generate_launch_config
 from arches_containers.utils.logger import AcOutputManager
+from arches_containers.utils.remote_catalog import fetch_remote_catalog, download_config_to_tempdir, CATALOG_REPO
 
 
 def _interactive_project_select(message, choices):
@@ -161,6 +162,7 @@ def main():
     import_prompt_group = parser_import.add_mutually_exclusive_group()
     import_prompt_group.add_argument("--yes", action="store_true", help="Answer yes to import prompts for non-interactive use.")
     import_prompt_group.add_argument("--no", action="store_true", help="Answer no to import prompts for non-interactive use.")
+    parser_import.add_argument("--catalog", action="store_true", default=False, help="Browse and import from the remote act-configs catalog (historicengland/act-configs).")
 
     # Sub-parser for the rehash command
     parser_rehash = subparsers.add_parser("rehash", help="Regenerate or set the hash used in Docker resource names", formatter_class=parser.formatter_class)
@@ -385,7 +387,56 @@ def main():
     # ========================================================================================================
     elif args.command == "import":
         AcOutputManager.write("▶️  Import project")
-        if args.project_name is None or args.project_name == "":
+        if args.catalog:
+            import shutil
+            tmpdir = None
+            try:
+                cache_dir = ac_workspace._get_ac_directory_path()
+                with AcOutputManager("Fetching available configs") as spinner:
+                    AcOutputManager.text(f"... Fetching available configs from {CATALOG_REPO}")
+                    try:
+                        catalog = fetch_remote_catalog(cache_dir)
+                    except RuntimeError as exc:
+                        AcOutputManager.fail(f"🔴 {exc}")
+                        exit(1)
+                if not catalog:
+                    AcOutputManager.fail("🔴 No configurations found in the remote catalog.")
+                    exit(1)
+                if args.project_name:
+                    match = next(
+                        (e for e in catalog if e["project_name"] == args.project_name),
+                        None,
+                    )
+                    if match is None:
+                        AcOutputManager.fail(
+                            f"🔴 Project '{args.project_name}' not found in the remote catalog."
+                        )
+                        exit(1)
+                else:
+                    choices = [e["display_name"] for e in catalog]
+                    selected = _interactive_project_select("Select a configuration to import:", choices)
+                    if selected is None:
+                        AcOutputManager.write("Selection cancelled.")
+                        exit(0)
+                    match = next(e for e in catalog if e["display_name"] == selected)
+                AcOutputManager.write(f"... Downloading config from remote...")
+                try:
+                    tmpdir = download_config_to_tempdir(match)
+                except RuntimeError as exc:
+                    AcOutputManager.fail(f"🔴 {exc}")
+                    exit(1)
+                prompt_default = True if args.yes else False if args.no else None
+                ac_workspace.import_project(
+                    match["project_name"],
+                    tmpdir,
+                    new_hash=args.new_hash,
+                    target_hash=args.hash_value,
+                    prompt_default=prompt_default,
+                )
+            finally:
+                if tmpdir is not None:
+                    shutil.rmtree(tmpdir, ignore_errors=True)
+        elif args.project_name is None or args.project_name == "":
             with AcOutputManager(f"... Discovering importable projects") as spinner:
                 AcOutputManager.text("... Discovering importable projects")
                 discovered = ac_workspace.discover_importable_projects()
@@ -402,16 +453,17 @@ def main():
             import_repo_path = match["repo_path"]
         else:
             import_repo_path = args.repo_path if args.repo_path else os.path.join(ac_workspace.path, args.project_name)
-        repo_path = args.repo_path if args.repo_path else import_repo_path
-        prompt_default = True if args.yes else False if args.no else None
-        AcOutputManager.write("... Importing project")
-        ac_workspace.import_project(
-            args.project_name,
-            repo_path,
-            new_hash=args.new_hash,
-            target_hash=args.hash_value,
-            prompt_default=prompt_default,
-        )
+        if not args.catalog:
+            repo_path = args.repo_path if args.repo_path else import_repo_path
+            prompt_default = True if args.yes else False if args.no else None
+            AcOutputManager.write("... Importing project")
+            ac_workspace.import_project(
+                args.project_name,
+                repo_path,
+                new_hash=args.new_hash,
+                target_hash=args.hash_value,
+                prompt_default=prompt_default,
+            )
 
     # ========================================================================================================
     elif args.command == "rehash":

--- a/arches_containers/main.py
+++ b/arches_containers/main.py
@@ -421,14 +421,14 @@ def main():
                     match = next(e for e in catalog if e["display_name"] == selected)
                 AcOutputManager.write(f"... Downloading config from remote...")
                 try:
-                    tmpdir = download_config_to_tempdir(match)
+                    tmpdir, import_path = download_config_to_tempdir(match)
                 except RuntimeError as exc:
                     AcOutputManager.fail(f"🔴 {exc}")
                     exit(1)
                 prompt_default = True if args.yes else False if args.no else None
                 ac_workspace.import_project(
                     match["project_name"],
-                    tmpdir,
+                    import_path,
                     new_hash=args.new_hash,
                     target_hash=args.hash_value,
                     prompt_default=prompt_default,

--- a/arches_containers/utils/remote_catalog.py
+++ b/arches_containers/utils/remote_catalog.py
@@ -1,0 +1,218 @@
+"""
+Remote catalog utilities for fetching and downloading Arches Container
+configurations from a centrally managed GitHub repository.
+"""
+
+import base64
+import json
+import os
+import re
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+CATALOG_REPO = "HistoricEngland/act-configs"
+CATALOG_BRANCH = "main"
+CACHE_FILENAME = "catalog_cache.json"
+CACHE_TTL = 3600  # seconds
+
+
+def _github_api_headers():
+    """Return headers for GitHub API requests."""
+    return {"Accept": "application/vnd.github+json"}
+
+
+def _github_api_get(url):
+    """Perform a GET request against the GitHub API and return parsed JSON."""
+    req = urllib.request.Request(url, headers=_github_api_headers())
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        if exc.code in (403, 429):
+            raise RuntimeError(
+                f"GitHub API rate limit exceeded (HTTP {exc.code}). "
+                "Please try again later."
+            ) from exc
+        raise RuntimeError(
+            f"GitHub API request failed (HTTP {exc.code}): {url}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"Unable to reach GitHub. Check your internet connection. ({exc.reason})"
+        ) from exc
+
+
+def _fetch_tree():
+    """Fetch the full recursive file tree from the catalog repository."""
+    url = (
+        f"https://api.github.com/repos/{CATALOG_REPO}/git/trees/{CATALOG_BRANCH}"
+        "?recursive=1"
+    )
+    data = _github_api_get(url)
+    if data.get("truncated"):
+        raise RuntimeError(
+            "Catalog repository tree was truncated by the GitHub API. "
+            "Contact the maintainers."
+        )
+    return [item["path"] for item in data.get("tree", []) if item.get("type") == "blob"]
+
+
+def _fetch_config_json(path):
+    """Fetch and decode a config.json file from the catalog via the GitHub Contents API."""
+    url = (
+        f"https://api.github.com/repos/{CATALOG_REPO}/contents/{path}"
+        f"?ref={CATALOG_BRANCH}"
+    )
+    data = _github_api_get(url)
+    content = base64.b64decode(data["content"]).decode("utf-8")
+    return json.loads(content)
+
+
+def _build_catalog_entries(all_paths):
+    """
+    Given the full list of file paths in the repo tree, find all config.json
+    files that match the pattern:
+        <display-name>/<catalog-version>/.ac_<project>/config.json
+
+    Fetches each config.json and returns a list of catalog entry dicts.
+    """
+    pattern = re.compile(r"^([^/]+)/([^/]+)/(\.[^/]+)/config\.json$")
+    entries = []
+    for path in all_paths:
+        m = pattern.match(path)
+        if not m:
+            continue
+        catalog_display, catalog_version, ac_folder = m.groups()
+        if not ac_folder.startswith(".ac_"):
+            continue
+
+        config = _fetch_config_json(path)
+        project_name = config.get("project_name", "")
+        arches_version = config.get("arches_version", "")
+        if not project_name:
+            continue
+
+        remote_folder = f"{catalog_display}/{catalog_version}/{ac_folder}"
+        folder_files = [p for p in all_paths if p.startswith(remote_folder + "/")]
+        display_name = f"{project_name}  (v{catalog_version} · Arches {arches_version})"
+        entries.append(
+            {
+                "project_name": project_name,
+                "arches_version": arches_version,
+                "catalog_version": catalog_version,
+                "display_name": display_name,
+                "remote_folder": remote_folder,
+                "all_files": folder_files,
+            }
+        )
+
+    entries.sort(key=lambda e: e["display_name"].lower())
+    return entries
+
+
+def _load_cache(cache_path):
+    """Load cache from disk. Returns None if missing, empty, or corrupt."""
+    try:
+        with open(cache_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if "timestamp" not in data or "configs" not in data:
+            return None
+        return data
+    except (OSError, ValueError, KeyError):
+        return None
+
+
+def _save_cache(cache_path, configs):
+    """Save configs list and current timestamp to cache. Failure is non-fatal."""
+    data = {"timestamp": time.time(), "configs": configs}
+    try:
+        with open(cache_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+    except OSError:
+        pass
+
+
+def fetch_remote_catalog(cache_dir):
+    """
+    Return the list of available configs from the remote catalog.
+
+    Uses a local cache in cache_dir with a TTL of CACHE_TTL seconds. Pass
+    cache_dir=None to skip caching entirely.
+
+    Each entry in the returned list is a dict with:
+        project_name     str  - e.g. "arches_her"
+        arches_version   str  - e.g. "7.6"
+        catalog_version  str  - e.g. "1.1"
+        display_name     str  - e.g. "arches_her  (v1.1 · Arches 7.6)"
+        remote_folder    str  - path in the catalog repo, e.g. "arches-her/1.1/.ac_arches_her"
+        all_files        list - repo-relative paths of every file inside remote_folder
+    """
+    if cache_dir is not None:
+        cache_path = os.path.join(cache_dir, CACHE_FILENAME)
+        cached = _load_cache(cache_path)
+        if cached and (time.time() - cached["timestamp"]) < CACHE_TTL:
+            return cached["configs"]
+
+    all_paths = _fetch_tree()
+    configs = _build_catalog_entries(all_paths)
+
+    if cache_dir is not None and os.path.isdir(cache_dir):
+        _save_cache(cache_path, configs)
+
+    return configs
+
+
+def download_config_to_tempdir(catalog_entry):
+    """
+    Download all files for a catalog entry from the remote repository into a
+    temporary directory structured as:
+
+        <tmpdir>/
+          .ac_<project_name>/
+            config.json
+            Dockerfile
+            docker/
+              ...
+
+    Returns the tmpdir path. The caller is responsible for cleanup (e.g. via
+    shutil.rmtree).
+    """
+    project_name = catalog_entry["project_name"]
+    remote_folder = catalog_entry["remote_folder"]
+    all_files = catalog_entry["all_files"]
+
+    tmpdir = tempfile.mkdtemp(prefix="act_catalog_")
+    ac_folder_name = f".ac_{project_name}"
+    ac_folder_path = os.path.join(tmpdir, ac_folder_name)
+    os.makedirs(ac_folder_path, exist_ok=True)
+
+    headers = _github_api_headers()
+    for file_path in all_files:
+        rel = os.path.relpath(file_path, remote_folder)
+        dest_path = os.path.join(ac_folder_path, rel)
+        dest_dir = os.path.dirname(dest_path)
+        if dest_dir:
+            os.makedirs(dest_dir, exist_ok=True)
+
+        raw_url = (
+            f"https://raw.githubusercontent.com/{CATALOG_REPO}"
+            f"/{CATALOG_BRANCH}/{file_path}"
+        )
+        req = urllib.request.Request(raw_url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                with open(dest_path, "wb") as out:
+                    out.write(resp.read())
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(
+                f"Failed to download remote file '{file_path}' (HTTP {exc.code})."
+            ) from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(
+                f"Unable to download '{file_path}'. "
+                f"Check your internet connection. ({exc.reason})"
+            ) from exc
+
+    return tmpdir

--- a/arches_containers/utils/remote_catalog.py
+++ b/arches_containers/utils/remote_catalog.py
@@ -170,49 +170,64 @@ def download_config_to_tempdir(catalog_entry):
     temporary directory structured as:
 
         <tmpdir>/
-          .ac_<project_name>/
-            config.json
-            Dockerfile
-            docker/
-              ...
+          <catalog_version>/          ← matches the version dir in act-configs
+            .ac_<project_name>/
+              config.json
+              Dockerfile
+              docker/
+                ...
 
-    Returns the tmpdir path. The caller is responsible for cleanup (e.g. via
-    shutil.rmtree).
+    The inner path ``<tmpdir>/<catalog_version>`` is returned alongside the
+    root tmpdir so that ``import_project()``'s path-rewriting logic resolves
+    the correct ``repo_dir_name`` (= ``catalog_version``) when replacing
+    compose-file references like ``./1.1/.ac_<project>/`` with
+    ``/.arches_containers/<project>/``.
+
+    Returns a tuple ``(tmpdir, import_path)`` where ``import_path`` is the
+    directory to pass to ``import_project()`` and ``tmpdir`` is the root to
+    clean up afterwards.
     """
     project_name = catalog_entry["project_name"]
     remote_folder = catalog_entry["remote_folder"]
     all_files = catalog_entry["all_files"]
+    catalog_version = catalog_entry["catalog_version"]
 
     tmpdir = tempfile.mkdtemp(prefix="act_catalog_")
-    ac_folder_name = f".ac_{project_name}"
-    ac_folder_path = os.path.join(tmpdir, ac_folder_name)
-    os.makedirs(ac_folder_path, exist_ok=True)
+    try:
+        inner_path = os.path.join(tmpdir, catalog_version)
+        ac_folder_name = f".ac_{project_name}"
+        ac_folder_path = os.path.join(inner_path, ac_folder_name)
+        os.makedirs(ac_folder_path, exist_ok=True)
 
-    headers = _github_api_headers()
-    for file_path in all_files:
-        rel = os.path.relpath(file_path, remote_folder)
-        dest_path = os.path.join(ac_folder_path, rel)
-        dest_dir = os.path.dirname(dest_path)
-        if dest_dir:
-            os.makedirs(dest_dir, exist_ok=True)
+        headers = _github_api_headers()
+        for file_path in all_files:
+            rel = os.path.relpath(file_path, remote_folder)
+            dest_path = os.path.join(ac_folder_path, rel)
+            dest_dir = os.path.dirname(dest_path)
+            if dest_dir:
+                os.makedirs(dest_dir, exist_ok=True)
 
-        raw_url = (
-            f"https://raw.githubusercontent.com/{CATALOG_REPO}"
-            f"/{CATALOG_BRANCH}/{file_path}"
-        )
-        req = urllib.request.Request(raw_url, headers=headers)
-        try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
-                with open(dest_path, "wb") as out:
-                    out.write(resp.read())
-        except urllib.error.HTTPError as exc:
-            raise RuntimeError(
-                f"Failed to download remote file '{file_path}' (HTTP {exc.code})."
-            ) from exc
-        except urllib.error.URLError as exc:
-            raise RuntimeError(
-                f"Unable to download '{file_path}'. "
-                f"Check your internet connection. ({exc.reason})"
-            ) from exc
+            raw_url = (
+                f"https://raw.githubusercontent.com/{CATALOG_REPO}"
+                f"/{CATALOG_BRANCH}/{file_path}"
+            )
+            req = urllib.request.Request(raw_url, headers=headers)
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    with open(dest_path, "wb") as out:
+                        out.write(resp.read())
+            except urllib.error.HTTPError as exc:
+                raise RuntimeError(
+                    f"Failed to download remote file '{file_path}' (HTTP {exc.code})."
+                ) from exc
+            except urllib.error.URLError as exc:
+                raise RuntimeError(
+                    f"Unable to download '{file_path}'. "
+                    f"Check your internet connection. ({exc.reason})"
+                ) from exc
+    except Exception:
+        import shutil as _shutil
+        _shutil.rmtree(tmpdir, ignore_errors=True)
+        raise
 
-    return tmpdir
+    return tmpdir, inner_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }
 keywords = ["arches", "development", "containers"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    "Development Status :: Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Affero General Public License v3",
     "Programming Language :: Python :: 3",

--- a/releases/1.2.0.md
+++ b/releases/1.2.0.md
@@ -1,0 +1,19 @@
+# Arches-containers tool (act) 1.2.0 Release Notes
+
+## Bug Fixes and Enhancements
+
+### Notable Changes
+
+- Adds ability to download remote configurations from act-configs Github repo [#117](https://github.com/HistoricEngland/arches-containers/pull/117).
+
+### Other Changes
+
+<!-- Add other changes here -->
+
+## Installation Instructions
+
+Activate your environment and run the following command to install the latest version of arches-containers:
+
+```bash
+pip install --upgrade arches-containers
+```

--- a/tests/test_remote_catalog.py
+++ b/tests/test_remote_catalog.py
@@ -326,6 +326,7 @@ def test_fetch_remote_catalog_skips_cache_when_none():
 def test_download_config_to_tempdir_creates_ac_folder(tmp_path, monkeypatch):
     entry = {
         "project_name": "arches_her",
+        "catalog_version": "1.1",
         "remote_folder": "arches-her/1.1/.ac_arches_her",
         "all_files": [
             "arches-her/1.1/.ac_arches_her/config.json",
@@ -347,24 +348,26 @@ def test_download_config_to_tempdir_creates_ac_folder(tmp_path, monkeypatch):
 
     import tempfile
 
-    original_mkdtemp = tempfile.mkdtemp
-
     def controlled_mkdtemp(**kwargs):
         return str(tmp_path / "act_catalog_test")
 
     monkeypatch.setattr(tempfile, "mkdtemp", controlled_mkdtemp)
 
-    tmpdir = download_config_to_tempdir(entry)
+    tmpdir, import_path = download_config_to_tempdir(entry)
 
-    assert os.path.isdir(os.path.join(tmpdir, ".ac_arches_her"))
-    assert os.path.isfile(os.path.join(tmpdir, ".ac_arches_her", "config.json"))
-    assert os.path.isfile(os.path.join(tmpdir, ".ac_arches_her", "docker", "entrypoint.sh"))
+    # import_path should be tmpdir/catalog_version so import_project resolves
+    # repo_dir_name = "1.1" — matching paths like "./1.1/.ac_arches_her/..." in compose files
+    assert os.path.basename(import_path) == "1.1"
+    assert os.path.isdir(os.path.join(import_path, ".ac_arches_her"))
+    assert os.path.isfile(os.path.join(import_path, ".ac_arches_her", "config.json"))
+    assert os.path.isfile(os.path.join(import_path, ".ac_arches_her", "docker", "entrypoint.sh"))
     assert file_counter[0] == 2
 
 
 def test_download_config_to_tempdir_raises_on_http_error(monkeypatch):
     entry = {
         "project_name": "arches_her",
+        "catalog_version": "1.1",
         "remote_folder": "arches-her/1.1/.ac_arches_her",
         "all_files": ["arches-her/1.1/.ac_arches_her/config.json"],
     }
@@ -379,6 +382,7 @@ def test_download_config_to_tempdir_raises_on_http_error(monkeypatch):
 def test_download_config_to_tempdir_raises_on_network_error(monkeypatch):
     entry = {
         "project_name": "arches_her",
+        "catalog_version": "1.1",
         "remote_folder": "arches-her/1.1/.ac_arches_her",
         "all_files": ["arches-her/1.1/.ac_arches_her/config.json"],
     }

--- a/tests/test_remote_catalog.py
+++ b/tests/test_remote_catalog.py
@@ -1,0 +1,390 @@
+import json
+import os
+import time
+import urllib.error
+from io import BytesIO
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from arches_containers.utils.remote_catalog import (
+    CACHE_FILENAME,
+    CACHE_TTL,
+    CATALOG_BRANCH,
+    CATALOG_REPO,
+    _build_catalog_entries,
+    _fetch_config_json,
+    _fetch_tree,
+    _github_api_headers,
+    _load_cache,
+    _save_cache,
+    download_config_to_tempdir,
+    fetch_remote_catalog,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_TREE_PATHS = [
+    "arches-her/1.1/.ac_arches_her/config.json",
+    "arches-her/1.1/.ac_arches_her/Dockerfile",
+    "arches-her/1.1/.ac_arches_her/docker-compose.yml",
+    "arches-her/1.1/.ac_arches_her/docker/entrypoint.sh",
+    "arches-lingo/1.0/.ac_arches_lingo/config.json",
+    "arches-lingo/1.0/.ac_arches_lingo/Dockerfile",
+    "README.md",
+]
+
+SAMPLE_CONFIGS = {
+    "arches-her/1.1/.ac_arches_her/config.json": {
+        "project_name": "arches_her",
+        "project_name_url_safe": "arches-her",
+        "project_repo_directory": "arches-her",
+        "project_hash": "c0d8d",
+        "arches_version": "7.6",
+        "arches_repo_organization": "archesproject",
+        "arches_repo_branch": "stable/7.6.22",
+    },
+    "arches-lingo/1.0/.ac_arches_lingo/config.json": {
+        "project_name": "arches_lingo",
+        "project_name_url_safe": "arches-lingo",
+        "project_repo_directory": "arches-lingo",
+        "project_hash": "ed22d",
+        "arches_version": "8.1",
+        "arches_repo_organization": "archesproject",
+        "arches_repo_branch": "stable/8.1.2",
+    },
+}
+
+
+def _make_api_response(data):
+    """Return a mock urllib response yielding JSON-encoded data."""
+    body = json.dumps(data).encode()
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = body
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _make_contents_response(data):
+    """Return a GitHub Contents API mock response (base64 encoded content)."""
+    import base64
+
+    raw = json.dumps(data).encode()
+    encoded = base64.b64encode(raw).decode()
+    return _make_api_response({"content": encoded + "\n"})
+
+
+# ---------------------------------------------------------------------------
+# _github_api_headers
+# ---------------------------------------------------------------------------
+
+
+def test_headers_accept_set():
+    headers = _github_api_headers()
+    assert headers == {"Accept": "application/vnd.github+json"}
+
+
+# ---------------------------------------------------------------------------
+# _fetch_tree
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_tree_returns_blob_paths():
+    tree_data = {
+        "truncated": False,
+        "tree": [
+            {"path": "arches-her/1.1/.ac_arches_her/config.json", "type": "blob"},
+            {"path": "arches-her/1.1/.ac_arches_her", "type": "tree"},
+            {"path": "README.md", "type": "blob"},
+        ],
+    }
+    with patch("urllib.request.urlopen", return_value=_make_api_response(tree_data)):
+        paths = _fetch_tree()
+    assert "arches-her/1.1/.ac_arches_her/config.json" in paths
+    assert "README.md" in paths
+    # tree entries (directories) should be excluded
+    assert "arches-her/1.1/.ac_arches_her" not in paths
+
+
+def test_fetch_tree_raises_on_truncation():
+    tree_data = {"truncated": True, "tree": []}
+    with patch("urllib.request.urlopen", return_value=_make_api_response(tree_data)):
+        with pytest.raises(RuntimeError, match="truncated"):
+            _fetch_tree()
+
+
+def test_fetch_tree_raises_on_rate_limit():
+    exc = urllib.error.HTTPError(url="", code=403, msg="Forbidden", hdrs=None, fp=None)
+    with patch("urllib.request.urlopen", side_effect=exc):
+        with pytest.raises(RuntimeError, match="rate limit"):
+            _fetch_tree()
+
+
+def test_fetch_tree_raises_on_network_error():
+    exc = urllib.error.URLError(reason="Name or service not known")
+    with patch("urllib.request.urlopen", side_effect=exc):
+        with pytest.raises(RuntimeError, match="internet connection"):
+            _fetch_tree()
+
+
+# ---------------------------------------------------------------------------
+# _build_catalog_entries
+# ---------------------------------------------------------------------------
+
+
+def test_build_catalog_entries():
+    def fake_fetch_config(path):
+        return SAMPLE_CONFIGS[path]
+
+    with patch(
+        "arches_containers.utils.remote_catalog._fetch_config_json",
+        side_effect=fake_fetch_config,
+    ):
+        entries = _build_catalog_entries(SAMPLE_TREE_PATHS)
+
+    assert len(entries) == 2
+    names = [e["project_name"] for e in entries]
+    assert "arches_her" in names
+    assert "arches_lingo" in names
+
+
+def test_build_catalog_entries_display_name_format():
+    def fake_fetch_config(path):
+        return SAMPLE_CONFIGS[path]
+
+    with patch(
+        "arches_containers.utils.remote_catalog._fetch_config_json",
+        side_effect=fake_fetch_config,
+    ):
+        entries = _build_catalog_entries(SAMPLE_TREE_PATHS)
+
+    her = next(e for e in entries if e["project_name"] == "arches_her")
+    assert her["display_name"] == "arches_her  (v1.1 · Arches 7.6)"
+    assert her["catalog_version"] == "1.1"
+    assert her["arches_version"] == "7.6"
+    assert her["remote_folder"] == "arches-her/1.1/.ac_arches_her"
+
+
+def test_build_catalog_entries_all_files_populated():
+    def fake_fetch_config(path):
+        return SAMPLE_CONFIGS[path]
+
+    with patch(
+        "arches_containers.utils.remote_catalog._fetch_config_json",
+        side_effect=fake_fetch_config,
+    ):
+        entries = _build_catalog_entries(SAMPLE_TREE_PATHS)
+
+    her = next(e for e in entries if e["project_name"] == "arches_her")
+    # config.json itself is not in all_files (it starts with remote_folder + "/")
+    assert "arches-her/1.1/.ac_arches_her/Dockerfile" in her["all_files"]
+    assert "arches-her/1.1/.ac_arches_her/docker/entrypoint.sh" in her["all_files"]
+    # README.md at root should not be included
+    assert "README.md" not in her["all_files"]
+
+
+def test_build_catalog_entries_skips_non_ac_folders():
+    paths = ["arches-her/1.1/.other_folder/config.json"]
+    entries = _build_catalog_entries(paths)
+    assert entries == []
+
+
+def test_build_catalog_entries_skips_missing_project_name():
+    def fake_fetch_config(path):
+        return {"arches_version": "7.6"}  # no project_name
+
+    paths = ["arches-her/1.1/.ac_arches_her/config.json"]
+    with patch(
+        "arches_containers.utils.remote_catalog._fetch_config_json",
+        side_effect=fake_fetch_config,
+    ):
+        entries = _build_catalog_entries(paths)
+    assert entries == []
+
+
+def test_build_catalog_entries_sorted_alphabetically():
+    def fake_fetch_config(path):
+        return SAMPLE_CONFIGS[path]
+
+    with patch(
+        "arches_containers.utils.remote_catalog._fetch_config_json",
+        side_effect=fake_fetch_config,
+    ):
+        entries = _build_catalog_entries(SAMPLE_TREE_PATHS)
+
+    display_names = [e["display_name"] for e in entries]
+    assert display_names == sorted(display_names, key=str.lower)
+
+
+# ---------------------------------------------------------------------------
+# _load_cache / _save_cache
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_cache(tmp_path):
+    configs = [{"project_name": "arches_her", "display_name": "arches_her  (v1.1 · Arches 7.6)"}]
+    cache_path = str(tmp_path / CACHE_FILENAME)
+    _save_cache(cache_path, configs)
+    loaded = _load_cache(cache_path)
+    assert loaded is not None
+    assert loaded["configs"] == configs
+    assert "timestamp" in loaded
+
+
+def test_load_cache_returns_none_for_missing_file(tmp_path):
+    cache_path = str(tmp_path / "nonexistent.json")
+    assert _load_cache(cache_path) is None
+
+
+def test_load_cache_returns_none_for_corrupt_json(tmp_path):
+    cache_path = tmp_path / CACHE_FILENAME
+    cache_path.write_text("not valid json")
+    assert _load_cache(str(cache_path)) is None
+
+
+def test_load_cache_returns_none_for_missing_keys(tmp_path):
+    cache_path = tmp_path / CACHE_FILENAME
+    cache_path.write_text(json.dumps({"only_timestamp": 0}))
+    assert _load_cache(str(cache_path)) is None
+
+
+def test_save_cache_is_non_fatal_on_write_error(tmp_path):
+    # Passing a path inside a non-existent directory should not raise
+    cache_path = str(tmp_path / "nonexistent_dir" / CACHE_FILENAME)
+    _save_cache(cache_path, [])  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# fetch_remote_catalog — cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_remote_catalog_uses_cache_when_fresh(tmp_path):
+    configs = [{"project_name": "arches_her"}]
+    cache_data = {"timestamp": time.time(), "configs": configs}
+    cache_path = tmp_path / CACHE_FILENAME
+    cache_path.write_text(json.dumps(cache_data))
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        result = fetch_remote_catalog(str(tmp_path))
+
+    mock_urlopen.assert_not_called()
+    assert result == configs
+
+
+def test_fetch_remote_catalog_refetches_stale_cache(tmp_path):
+    configs = [{"project_name": "arches_her"}]
+    stale_timestamp = time.time() - CACHE_TTL - 60
+    cache_data = {"timestamp": stale_timestamp, "configs": configs}
+    (tmp_path / CACHE_FILENAME).write_text(json.dumps(cache_data))
+
+    def fake_fetch_config(path):
+        return SAMPLE_CONFIGS[path]
+
+    tree_data = {
+        "truncated": False,
+        "tree": [{"path": p, "type": "blob"} for p in SAMPLE_TREE_PATHS],
+    }
+    with patch("urllib.request.urlopen", return_value=_make_api_response(tree_data)):
+        with patch(
+            "arches_containers.utils.remote_catalog._fetch_config_json",
+            side_effect=fake_fetch_config,
+        ):
+            result = fetch_remote_catalog(str(tmp_path))
+
+    assert len(result) == 2
+
+
+def test_fetch_remote_catalog_skips_cache_when_none():
+    def fake_fetch_config(path):
+        return SAMPLE_CONFIGS[path]
+
+    tree_data = {
+        "truncated": False,
+        "tree": [{"path": p, "type": "blob"} for p in SAMPLE_TREE_PATHS],
+    }
+    with patch("urllib.request.urlopen", return_value=_make_api_response(tree_data)) as mock_urlopen:
+        with patch(
+            "arches_containers.utils.remote_catalog._fetch_config_json",
+            side_effect=fake_fetch_config,
+        ):
+            result = fetch_remote_catalog(cache_dir=None)
+
+    assert len(result) == 2
+    # No cache file written (would have required a real dir)
+
+
+# ---------------------------------------------------------------------------
+# download_config_to_tempdir
+# ---------------------------------------------------------------------------
+
+
+def test_download_config_to_tempdir_creates_ac_folder(tmp_path, monkeypatch):
+    entry = {
+        "project_name": "arches_her",
+        "remote_folder": "arches-her/1.1/.ac_arches_her",
+        "all_files": [
+            "arches-her/1.1/.ac_arches_her/config.json",
+            "arches-her/1.1/.ac_arches_her/docker/entrypoint.sh",
+        ],
+    }
+
+    file_counter = [0]
+
+    def fake_urlopen(req, timeout=15):
+        file_counter[0] += 1
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = b"file content"
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        return mock_resp
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    import tempfile
+
+    original_mkdtemp = tempfile.mkdtemp
+
+    def controlled_mkdtemp(**kwargs):
+        return str(tmp_path / "act_catalog_test")
+
+    monkeypatch.setattr(tempfile, "mkdtemp", controlled_mkdtemp)
+
+    tmpdir = download_config_to_tempdir(entry)
+
+    assert os.path.isdir(os.path.join(tmpdir, ".ac_arches_her"))
+    assert os.path.isfile(os.path.join(tmpdir, ".ac_arches_her", "config.json"))
+    assert os.path.isfile(os.path.join(tmpdir, ".ac_arches_her", "docker", "entrypoint.sh"))
+    assert file_counter[0] == 2
+
+
+def test_download_config_to_tempdir_raises_on_http_error(monkeypatch):
+    entry = {
+        "project_name": "arches_her",
+        "remote_folder": "arches-her/1.1/.ac_arches_her",
+        "all_files": ["arches-her/1.1/.ac_arches_her/config.json"],
+    }
+
+    exc = urllib.error.HTTPError(url="", code=404, msg="Not Found", hdrs=None, fp=None)
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=15: (_ for _ in ()).throw(exc))
+
+    with pytest.raises(RuntimeError, match="HTTP 404"):
+        download_config_to_tempdir(entry)
+
+
+def test_download_config_to_tempdir_raises_on_network_error(monkeypatch):
+    entry = {
+        "project_name": "arches_her",
+        "remote_folder": "arches-her/1.1/.ac_arches_her",
+        "all_files": ["arches-her/1.1/.ac_arches_her/config.json"],
+    }
+
+    exc = urllib.error.URLError(reason="Connection refused")
+    monkeypatch.setattr("urllib.request.urlopen", lambda req, timeout=15: (_ for _ in ()).throw(exc))
+
+    with pytest.raises(RuntimeError, match="internet connection"):
+        download_config_to_tempdir(entry)


### PR DESCRIPTION
Closes #113 

This pull request introduces a major new feature to the `arches_containers` tool: the ability to browse and import project configurations directly from a centrally managed remote catalog (the `act-configs` GitHub repository). This enhancement streamlines the process of importing standardized project setups and includes robust error handling, caching, and cleanup. Additionally, release notes for version 1.2.0 have been added.

**Remote catalog import feature:**

* Added `--catalog` flag to the `import` command in `main.py`, enabling users to browse and import configurations from the remote `act-configs` GitHub repository.
* Implemented logic in `main.py` to handle remote catalog selection, download the selected configuration to a temporary directory, and import it, with appropriate error handling and cleanup. [[1]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adL388-R439) [[2]](diffhunk://#diff-5d01c6a065d033bf087e2aa5f122b7d9772fb969b9aa3f615b0f742afc9df5adR456)
* Added new module `utils/remote_catalog.py` providing functions to fetch the remote catalog, cache results, and download selected configurations, including GitHub API integration and file extraction logic.
* Updated imports in `main.py` to include the new remote catalog utilities.

**Documentation:**

* Added release notes for version 1.2.0 in `releases/1.2.0.md`, highlighting the new remote catalog import feature and providing installation instructions.