### PR TITLE
Fixes Window compatibility issue during up command

### DIFF
--- a/arches_containers/manage.py
+++ b/arches_containers/manage.py
@@ -83,7 +83,7 @@ def compose_project(project_name, action="up", build=False, verbose=False, conta
     
     for compose_file in compose_files:
         if compose_file == DOCKER_COMPOSE_FILE and action == "up":
-            subprocess.run(["sleep", "15"])
+            sleep(15)
 
         compose_file_path = os.path.join(project_path, compose_file)
 

--- a/releases/1.1.1.md
+++ b/releases/1.1.1.md
@@ -1,0 +1,25 @@
+# Arches-containers tool (act) 1.1.1 Release Notes
+
+## Bug Fixes and Enhancements
+
+- Correctly defines minimum supported Python version as 3.9 in `pyproject.toml` to align with actual dependency support
+
+### Breaking Change
+
+...
+
+### Notable Changes
+
+...
+
+### Other Changes
+
+...
+
+## Installation Instructions
+
+Activate your environment and run the following command to install the latest version of arches-containers:
+
+```bash
+pip install --upgrade arches-containers
+```

--- a/releases/1.1.2.md
+++ b/releases/1.1.2.md
@@ -1,0 +1,25 @@
+# Arches-containers tool (act) 1.1.2 Release Notes
+
+## Bug Fixes and Enhancements
+
+- Fixes issue with service startup on Windows when using up command [#120](https://github.com/HistoricEngland/arches-containers/pull/120)
+
+### Breaking Change
+
+...
+
+### Notable Changes
+
+...
+
+### Other Changes
+
+...
+
+## Installation Instructions
+
+Activate your environment and run the following command to install the latest version of arches-containers:
+
+```bash
+pip install --upgrade arches-containers
+```


### PR DESCRIPTION
This pull request includes a bug fix to improve cross-platform compatibility and adds release notes for versions 1.1.1 and 1.1.2 of the `arches-containers` tool. The most important changes are:

Bug Fixes:

* Replaces the use of `subprocess.run(["sleep", "15"])` with a direct call to `sleep(15)` in `manage.py` to fix service startup issues on Windows when running the `up` command.

Documentation:

* Adds release notes for version 1.1.2, highlighting the Windows startup fix and providing installation instructions.
* Adds missing release notes for version 1.1.1, including clarification of the minimum supported Python version and installation instructions.

Fixes #119 