### PR TITLE
Adds fix for local Arches not being installed

### DIFF
--- a/arches_containers/template/_7.6_/Dockerfile
+++ b/arches_containers/template/_7.6_/Dockerfile
@@ -124,3 +124,11 @@ COPY ${PROJ_REPO_NAME}/ ${WEB_ROOT}/${PROJ_NAME}/
 
 # Install the project as an editable package so Django can import it
 RUN pip install -e ${WEB_ROOT}/${PROJ_NAME}
+
+# By default we resintall arches from ARCHES_ROOT to allow debug and development of Arches.
+# If you comment this out, you'll install what meets the version requirements of the project package.
+WORKDIR ${ARCHES_ROOT}
+RUN pip install -e '.[dev]'
+
+# Set default workdir
+WORKDIR ${WEB_ROOT}

--- a/arches_containers/template/_8.0_/Dockerfile
+++ b/arches_containers/template/_8.0_/Dockerfile
@@ -114,3 +114,11 @@ COPY ${PROJ_REPO_NAME}/ ${WEB_ROOT}/${PROJ_NAME}/
 
 # Install the project as an editable package so Django can import it
 RUN pip install -e ${WEB_ROOT}/${PROJ_NAME}
+
+# By default we resintall arches from ARCHES_ROOT to allow debug and development of Arches.
+# If you comment this out, you'll install what meets the version requirements of the project package.
+WORKDIR ${ARCHES_ROOT}
+RUN pip install -e '.[dev]'
+
+# Set default workdir
+WORKDIR ${WEB_ROOT}

--- a/arches_containers/template/_8.1_/Dockerfile
+++ b/arches_containers/template/_8.1_/Dockerfile
@@ -114,3 +114,11 @@ COPY ${PROJ_REPO_NAME}/ ${WEB_ROOT}/${PROJ_NAME}/
 
 # Install the project as an editable package so Django can import it
 RUN pip install -e ${WEB_ROOT}/${PROJ_NAME}
+
+# By default we resintall arches from ARCHES_ROOT to allow debug and development of Arches.
+# If you comment this out, you'll install what meets the version requirements of the project package.
+WORKDIR ${ARCHES_ROOT}
+RUN pip install -e '.[dev]'
+
+# Set default workdir
+WORKDIR ${WEB_ROOT}

--- a/releases/1.1.2.md
+++ b/releases/1.1.2.md
@@ -24,3 +24,17 @@ Activate your environment and run the following command to install the latest ve
 ```bash
 pip install --upgrade arches-containers
 ```
+
+## Updates needed to ACT configs
+
+1. If you used v1.1.1 to create a config project, you will need to update your Dockerfile to ensure that the local Arches repo is installed after the project. You can do this by adding the following lines to your `./arches_containers/<your project name>/Dockerfile` after the line that installs the project with `RUN pip install -e ${WEB_ROOT}/${PROJ_NAME}`:
+
+```dockerfile
+# By default we resintall arches from ARCHES_ROOT to allow debug and development of Arches.
+# If you comment this out, you'll install what meets the version requirements of the project package.
+WORKDIR ${ARCHES_ROOT}
+RUN pip install -e '.[dev]'
+
+# Set default workdir
+WORKDIR ${WEB_ROOT}
+```

--- a/releases/1.1.2.md
+++ b/releases/1.1.2.md
@@ -3,6 +3,7 @@
 ## Bug Fixes and Enhancements
 
 - Fixes issue with service startup on Windows when using up command [#120](https://github.com/HistoricEngland/arches-containers/pull/120)
+- Fixes local arches repo not being installed after the project as expected [#124](https://github.com/HistoricEngland/arches-containers/pull/124)
 
 ### Breaking Change
 


### PR DESCRIPTION
This pull request addresses an installation order issue in the Dockerfiles for Arches containers, ensuring that the local Arches repository is installed after the project package. This change supports better development and debugging workflows. The release notes and upgrade instructions have also been updated to reflect this fix and guide users on making necessary adjustments to their configurations.

**Dockerfile updates for Arches installation:**

* Updated Dockerfiles for versions 7.6, 8.0, and 8.1 in `arches_containers/template/` to reinstall the local Arches repo from `ARCHES_ROOT` after installing the project, supporting local development and debugging. [[1]](diffhunk://#diff-e5b196fe223705cb4493fb36f2f0bb5c3af4f950336358c55a784f05112140dbR127-R134) [[2]](diffhunk://#diff-90e754d042867efd67b18ad249a1ec07d2022b23eae754ad805b3945ce5d9893R117-R124)

**Documentation and release notes:**

* Added a bug fix entry in `releases/1.1.2.md` documenting the fix for the local Arches repo installation order.
* Provided detailed upgrade instructions in `releases/1.1.2.md` for users who created config projects with v1.1.1, explaining how to update their Dockerfile to ensure correct installation order.

Fixes #123