### PR TITLE
Fix project creation logic to handle cases without directory separators

### DIFF
--- a/arches_containers/template/_7.6_/docker/entrypoint.sh
+++ b/arches_containers/template/_7.6_/docker/entrypoint.sh
@@ -101,8 +101,12 @@ create_arches_project_only(){
 	echo ""
 	if ! project_exists; then
 		cd ${WEB_ROOT}
-		mkdir -p ${ARCHES_PROJECT_REPO_DIRECTORY}
-		python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT} -d ${ARCHES_PROJECT_REPO_DIRECTORY}
+		if [[ ${ARCHES_PROJECT} != ${ARCHES_PROJECT_REPO_DIRECTORY} ]]; then
+			mkdir -p ${ARCHES_PROJECT_REPO_DIRECTORY}
+			python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT} -d ${ARCHES_PROJECT_REPO_DIRECTORY}
+		else
+			python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT}
+		fi
 		echo "...Checking directories are created..."
 		sleep 2
 		if ! project_exists; then

--- a/arches_containers/template/_8.0_/docker/entrypoint.sh
+++ b/arches_containers/template/_8.0_/docker/entrypoint.sh
@@ -101,8 +101,12 @@ create_arches_project_only(){
 	echo ""
 	if ! project_exists; then
 		cd ${WEB_ROOT}
-		mkdir -p ${ARCHES_PROJECT_REPO_DIRECTORY}
-		python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT} -d ${ARCHES_PROJECT_REPO_DIRECTORY}
+		if [[ ${ARCHES_PROJECT} != ${ARCHES_PROJECT_REPO_DIRECTORY} ]]; then
+			mkdir -p ${ARCHES_PROJECT_REPO_DIRECTORY}
+			python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT} -d ${ARCHES_PROJECT_REPO_DIRECTORY}
+		else
+			python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT}
+		fi
 		echo "...Checking directories are created..."
 		sleep 2
 		if ! project_exists; then

--- a/arches_containers/template/_8.1_/docker/entrypoint.sh
+++ b/arches_containers/template/_8.1_/docker/entrypoint.sh
@@ -101,8 +101,12 @@ create_arches_project_only(){
 	echo ""
 	if ! project_exists; then
 		cd ${WEB_ROOT}
-		mkdir -p ${ARCHES_PROJECT_REPO_DIRECTORY}
-		python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT} -d ${ARCHES_PROJECT_REPO_DIRECTORY}
+		if [[ ${ARCHES_PROJECT} != ${ARCHES_PROJECT_REPO_DIRECTORY} ]]; then
+			mkdir -p ${ARCHES_PROJECT_REPO_DIRECTORY}
+			python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT} -d ${ARCHES_PROJECT_REPO_DIRECTORY}
+		else
+			python3 ${WEB_ROOT}/arches/arches/install/arches_admin.py startproject ${ARCHES_PROJECT}
+		fi
 		echo "...Checking directories are created..."
 		sleep 2
 		if ! project_exists; then

--- a/releases/1.1.2.md
+++ b/releases/1.1.2.md
@@ -3,6 +3,7 @@
 ## Bug Fixes and Enhancements
 
 - Fixes issue with service startup on Windows when using up command [#120](https://github.com/HistoricEngland/arches-containers/pull/120)
+- Fixes issue with project names that have no separators not being created [#126](https://github.com/HistoricEngland/arches-containers/pull/126)
 - Fixes local arches repo not being installed after the project as expected [#124](https://github.com/HistoricEngland/arches-containers/pull/124)
 
 ### Breaking Change


### PR DESCRIPTION
Fixes the issue were project names that have no spaces creates it's install location, which Django then thinks it will create a duplicate module, and fails.

The solution was that you can only pass in the target directory parameter if it has a different name to the module, which happens naturally with a separator as the repo and module are slugged with a hyphen and underscore respectively.

Complets #118