### PR TITLE
Refactor service availability check to be cross platform

### DIFF
--- a/arches_containers/__init__.py
+++ b/arches_containers/__init__.py
@@ -1,1 +1,1 @@
-AC_VERSION = "1.1.2"
+AC_VERSION = "1.1.2rc3"

--- a/arches_containers/manage.py
+++ b/arches_containers/manage.py
@@ -1,6 +1,8 @@
 import os, sys
 import subprocess
 from time import sleep, time
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
 from arches_containers.utils.workspace import AcWorkspace, AcSettings, AcProject
 import arches_containers.utils.arches_repo_helper as arches_repo_helper
 from arches_containers.utils.logger import AcOutputManager
@@ -19,13 +21,15 @@ def test_project_service_available_with_status_200(project_name) -> bool:
     host = ac_settings["host"]
     port = ac_settings["port"]
     url = f"http://{host}:{port}/"
-    result = subprocess.run(
-        ["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", url],
-        stdout=subprocess.PIPE,
-        text=True,
-        stderr=subprocess.DEVNULL,
-    )
-    return result.returncode == 0 and result.stdout.strip() == "200"
+    try:
+        with urlopen(url, timeout=5) as response:
+            return response.status == 200
+    except HTTPError:
+        return False
+    except URLError:
+        return False
+    except Exception:
+        return False
 
 def _image_build_needed(compose_file_path, project_path):
     '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "arches-containers"
-version = "1.1.2"
+version = "1.1.2rc3"
 description = "A python developer tool for Arches Project that provides a way to create arches development environments. Provides templates for Arches v6.1 to v8.1 (v7.6 to v8.1 in active support)."
 requires-python = ">=3.9"
 license = { text = "AGPL-3.0" }

--- a/releases/1.1.2.md
+++ b/releases/1.1.2.md
@@ -5,6 +5,7 @@
 - Fixes issue with service startup on Windows when using up command [#120](https://github.com/HistoricEngland/arches-containers/pull/120)
 - Fixes issue with project names that have no separators not being created [#126](https://github.com/HistoricEngland/arches-containers/pull/126)
 - Fixes local arches repo not being installed after the project as expected [#124](https://github.com/HistoricEngland/arches-containers/pull/124)
+- Fixes service-health check on Windows [#128](https://github.com/HistoricEngland/arches-containers/pull/128)
 
 ### Breaking Change
 


### PR DESCRIPTION
This pull request refactors the way the service availability is checked in the `arches_containers/manage.py` script. The main change is replacing the use of a subprocess call to `curl` with a direct Python-based HTTP request, which improves portability and reliability.

**Refactor service availability check:**

* Replaced the subprocess-based `curl` call in `test_project_service_available_with_status_200` with a Python-native implementation using `urllib.request.urlopen`, improving cross-platform compatibility and reducing external dependencies.
* Added imports for `HTTPError`, `URLError`, and `urlopen` from `urllib`, supporting the new HTTP request approach.


Fixes #127 